### PR TITLE
Add QueryDict

### DIFF
--- a/responder/models.py
+++ b/responder/models.py
@@ -26,6 +26,75 @@ def flatten(d):
 
     return d
 
+# WIP
+class QueryDict(dict):
+    def __init__(self, query_string):
+        query_string = query_string
+        self.update(parse_qs(query_string))
+
+    def __getitem__(self, key):
+        """
+        Return the last data value for this key, or [] if it's an empty list;
+        raise KeyError if not found.
+        """
+        list_ = super().__getitem__(key)
+        try:
+            return list_[-1]
+        except IndexError:
+            return []
+
+    def get(self, key, default=None):
+        """
+        Return the last data value for the passed key. If key doesn't exist
+        or value is an empty list, return `default`.
+        """
+        try:
+            val = self[key]
+        except KeyError:
+            return default
+        if val == []:
+            return default
+        return val
+
+    def _get_list(self, key, default=None, force_list=False):
+        """
+        Return a list of values for the key.
+
+        Used internally to manipulate values list. If force_list is True,
+        return a new copy of values.
+        """
+        try:
+            values = super().__getitem__(key)
+        except KeyError:
+            if default is None:
+                return []
+            return default
+        else:
+            if force_list:
+                values = list(values) if values is not None else None
+            return values
+
+    def get_list(self, key, default=None):
+        """
+        Return the list of values for the key. If key doesn't exist, return a
+        default value.
+        """
+        return self._get_list(key, default, force_list=True)
+
+    def items(self):
+        """
+        Yield (key, value) pairs, where value is the last item in the list
+        associated with the key.
+        """
+        for key in self:
+            yield key, self[key]
+
+    def items_list(self):
+        """
+        Yield (key, value) pairs, where value is the the list.
+        """
+        yield from super().items()
+
 
 # TODO: add slots
 class Request:
@@ -50,8 +119,8 @@ class Request:
         self.path = (
             self._wz.path
         )  #: The path portion of the URL of the Request, without query parameters.
-        self.params = flatten(
-            parse_qs(self._wz.query_string.decode("utf-8"))
+        self.params = (
+            QueryDict(self._wz.query_string.decode("utf-8"))
         )  #: A dictionary of the parsed query paramaters used for the Request.
         self.query = self._wz.query_string.decode(
             "utf-8"

--- a/test_responder.py
+++ b/test_responder.py
@@ -186,6 +186,9 @@ def test_query_params(api):
 
     r = api.session().get("http://;/?q=q")
     assert r.json()["params"] == {"q": "q"}
+    
+    r = api.session().get("http://;/?q=1&q=2&q=3")
+    assert r.json()["params"] == {"q": "3"}
 
 
 def test_form_data(api):


### PR DESCRIPTION
To handle query params, responder is using [parse_qs](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.parse_qs), which returns a dictionary with query variable names as keys and lists of values for each name for the values, and if a value have 1 element, responder set that value to that one element.

So for `?a=1&a=2&a=3&b=4` the params dict is `{a: [1, 2, 3], b: 4}`, which is confusing and it can lead to errors if we're is not aware, for instance `?a=1 => {a: 1}` and `"?a=1&a=2&a=3" => {a: [1, 2, 3]}` we need to handle both cases.

So I've made a minimalistic class to handle multi values params (inspired by django [QueryDict](https://github.com/django/django/blob/master/django/http/request.py#L362)), it stores the values in a list and returns the last element ( I guess it's the expected behavior)

```
>>> query_dict = QueryDict("a=1&a=2&a=3&b=4")
>>> query_dict[a]
3
>>> query_dict.get_list('a')
[1, 2, 3]
>>> query_dict.get_list('b')
[4]
>>> query_dict.get('not_found')
[]
>>> query_dict.get('not_found', 'default_value')
default_value
```  
