### PR TITLE
Don't break when "Accept" header is missing

### DIFF
--- a/responder/models.py
+++ b/responder/models.py
@@ -143,7 +143,7 @@ class Request:
 
     def accepts(self, content_type):
         """Returns ``True`` if the incoming Request accepts the given ``content_type``."""
-        return content_type in self.headers["Accept"]
+        return content_type in self.headers.get("Accept", [])
 
     def media(self, format=None):
         """Renders incoming json/yaml/form data as Python objects.


### PR DESCRIPTION
Noticed this error when testing an endpoint from [Paw](https://paw.cloud) (which doesn't send `Accept` header by default).

```
ERROR: Exception in ASGI application
Traceback (most recent call last):
  File "uvicorn/protocols/http/httptools_impl.py", line 384, in run_asgi
    result = await asgi(self.receive, self.send)
  File "uvicorn/middleware/message_logger.py", line 52, in __call__
    await inner(self.receive, self.send)
  File "responder/responder/api.py", line 84, in asgi
    await resp(receive, send)
  File "responder/responder/models.py", line 234, in __call__
    body, headers = self.body
  File "responder/responder/models.py", line 198, in body
    if self.req.accepts(format):
  File "responder/responder/models.py", line 146, in accepts
    return content_type in self.headers["Accept"]
  File "requests/structures.py", line 52, in __getitem__
    return self._store[key.lower()][1]
KeyError: 'accept'
```