### PR TITLE
Depend on apispec>=1.0.0b1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ required = [
     "rfc3986",
     "python-multipart",
     "chardet",
-    "apispec",
+    "apispec>=1.0.0b1",
     "marshmallow",
 ]
 


### PR DESCRIPTION
The current code depends on the `apispec.yaml_utils`
module, which only exists in apispec 1.0.0b.

Close #52