### PR TITLE
Routes matching for humans

### DIFF
--- a/responder/api.py
+++ b/responder/api.py
@@ -222,9 +222,10 @@ class API:
         """
         if check_existing:
             assert route not in self.routes
-
         # TODO: Support grpahiql.
         self.routes[route] = Route(route, endpoint)
+        # TODO: A better datastructer or sort it once the app is loaded
+        self.routes = dict(sorted(self.routes.items(), key=lambda item: item[1]._weight()))
 
     def default_response(self, req, resp):
         resp.status_code = status_codes.HTTP_404

--- a/responder/routes.py
+++ b/responder/routes.py
@@ -1,5 +1,5 @@
 from parse import parse, search
-
+import re
 
 def memoize(f):
     def helper(self, s):
@@ -55,3 +55,8 @@ class Route:
             url = f"http://;{url}"
 
         return url
+
+    def _weight(self):
+        l = -len(set(re.findall(r'{([a-zA-Z]\w*)}', self.route)))
+        return l != 0, l
+


### PR DESCRIPTION
Currently the routes are matched based on the insertion order and they can shadow each other, and as human being this is not the expected behavior xD.

Given the following order, the routes are `['/{who}', '/test', '{/person/how}']`
```
@api.route("/{who}")
def endpoint_1(req, resp, *, who="Taoufik"):
    resp.media = {"Hello": who}

@api.route("/test")
def endpoint_2(req, resp):
    resp.media = {"Good bye": "world"}

@api.route("/{person}/{how}")
def endpoint_3(req, resp, *, person, how):
    resp.media = { how: person}
```
The first endpoint will shadow all the other endpoints, no matter what it will return `{ "Hello": "param/param"}` 

And since it's written for human beings, I've sorted the routes based on a weight, first the routes with no parameters then those with the highest number of parameters.
So the routes will be : `['/test', '/{person}/{how}', '/{who}']`

For now the weight is just the number of parameters and I think it's sufficient.
