### PR TITLE
Support ASGI middleware

### DIFF
--- a/responder/models.py
+++ b/responder/models.py
@@ -250,35 +250,35 @@ class Response:
             {"Content-Type": "application/json"},
         )
 
-    @property
-    async def gzipped_body(self):
-
-        body, headers = await self.body
-
-        if isinstance(body, str):
-            body = body.encode(self.encoding)
-
-        if "gzip" in self.req.headers["Accept-Encoding"].lower():
-            gzip_buffer = io.BytesIO()
-            gzip_file = gzip.GzipFile(mode="wb", fileobj=gzip_buffer)
-            gzip_file.write(body)
-            gzip_file.close()
-
-            new_headers = {
-                "Content-Encoding": "gzip",
-                "Vary": "Accept-Encoding",
-                "Content-Length": str(len(body)),
-            }
-            headers.update(new_headers)
-
-            return (gzip_buffer.getvalue(), headers)
-        else:
-            return (body, headers)
+    # @property
+    # async def gzipped_body(self):
+    #
+    #     body, headers = await self.body
+    #
+    #     if isinstance(body, str):
+    #         body = body.encode(self.encoding)
+    #
+    #     if "gzip" in self.req.headers["Accept-Encoding"].lower():
+    #         gzip_buffer = io.BytesIO()
+    #         gzip_file = gzip.GzipFile(mode="wb", fileobj=gzip_buffer)
+    #         gzip_file.write(body)
+    #         gzip_file.close()
+    #
+    #         new_headers = {
+    #             "Content-Encoding": "gzip",
+    #             "Vary": "Accept-Encoding",
+    #             "Content-Length": str(len(body)),
+    #         }
+    #         headers.update(new_headers)
+    #
+    #         return (gzip_buffer.getvalue(), headers)
+    #     else:
+    #         return (body, headers)
 
     async def __call__(self, receive, send):
         body, headers = await self.body
-        if len(await self.body) > 500:
-            body, headers = await self.gzipped_body
+        # if len(await self.body) > 500:
+        #     body, headers = await self.gzipped_body
         if self.headers:
             headers.update(self.headers)
 

--- a/responder/models.py
+++ b/responder/models.py
@@ -250,35 +250,8 @@ class Response:
             {"Content-Type": "application/json"},
         )
 
-    # @property
-    # async def gzipped_body(self):
-    #
-    #     body, headers = await self.body
-    #
-    #     if isinstance(body, str):
-    #         body = body.encode(self.encoding)
-    #
-    #     if "gzip" in self.req.headers["Accept-Encoding"].lower():
-    #         gzip_buffer = io.BytesIO()
-    #         gzip_file = gzip.GzipFile(mode="wb", fileobj=gzip_buffer)
-    #         gzip_file.write(body)
-    #         gzip_file.close()
-    #
-    #         new_headers = {
-    #             "Content-Encoding": "gzip",
-    #             "Vary": "Accept-Encoding",
-    #             "Content-Length": str(len(body)),
-    #         }
-    #         headers.update(new_headers)
-    #
-    #         return (gzip_buffer.getvalue(), headers)
-    #     else:
-    #         return (body, headers)
-
     async def __call__(self, receive, send):
         body, headers = await self.body
-        # if len(await self.body) > 500:
-        #     body, headers = await self.gzipped_body
         if self.headers:
             headers.update(self.headers)
 


### PR DESCRIPTION
Refs #51

Adds support for ASGI middleware.

* Moves GZip implementation into middleware, adds support for gzipping streaming responses.
* Enables easy support for CORS via https://www.starlette.io/middleware/#corsmiddleware

In the future you might want a higher-level abstraction for middleware, but I think the *right* way around to do that is not to build a new middleware API, but rather to have a higher level abstraction for the developer that *exposes* itself as regular ASGI middleware.

For example, I'm expecting that Starlette will at some point have a `RequestResponseMiddleware` class that you can use to work at the request/response level, while still ending up with a cross-framework-compatible ASGI middleware class, so the developer interface can be something like this...

```python
class MyMiddleware(RequestResponseMiddleware):
    async def dispatch(request, call_next):
        # Modify the request, or whatever.
        response = call_next(request)
        # Modify the response, or whatever.
        return response
```

 and the ASGI `__call__(scope)` interface is automatically provided for you.