### PR TITLE
Add .python-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode/
 .cache
 .idea
+.python-version
 .coverage
 .pytest_cache
 .DS_Store


### PR DESCRIPTION
.python-version allows to specify separate pyenv virtual environment