### PR TITLE
Fixes #100 Added custom cookie name for sessions

### DIFF
--- a/responder/api.py
+++ b/responder/api.py
@@ -48,6 +48,7 @@ class API:
         static_route="/static",
         templates_dir="templates",
         secret_key="NOTASECRET",
+        session_cookie="Responder-Session",
         enable_hsts=False,
     ):
         self.secret_key = secret_key
@@ -57,6 +58,7 @@ class API:
         self.static_dir = Path(os.path.abspath(static_dir))
         self.static_route = static_route
         self.templates_dir = Path(os.path.abspath(templates_dir))
+        self.session_cookie = session_cookie
         self.built_in_templates_dir = Path(
             os.path.abspath(os.path.dirname(__file__) + "/templates")
         )
@@ -191,7 +193,7 @@ class API:
 
         if resp.session:
             data = self._signer.sign(json.dumps(resp.session).encode("utf-8"))
-            resp.cookies["Responder-Session"] = data.decode("utf-8")
+            resp.cookies[self.session_cookie] = data.decode("utf-8")
 
     async def _dispatch_request(self, req):
         # Set formats on Request object.

--- a/responder/models.py
+++ b/responder/models.py
@@ -107,8 +107,8 @@ class Request:
     @property
     def session(self):
         """The session data, in dict form, from the Request."""
-        if "Responder-Session" in self.cookies:
-            data = self.cookies["Responder-Session"]
+        if self.api.session_cookie in self.cookies:
+            data = self.cookies[self.api.session_cookie]
             data = self.api._signer.unsign(data)
             return json.loads(data)
         return {}

--- a/responder/models.py
+++ b/responder/models.py
@@ -107,8 +107,13 @@ class Request:
     @property
     def session(self):
         """The session data, in dict form, from the Request."""
-        if self.api.session_cookie in self.cookies:
-            data = self.cookies[self.api.session_cookie]
+        session_cookie = None
+        if not self.api:
+            session_cookie = "Responder-Session"
+        else:
+            session_cookie = self.api.session_cookie
+        if session_cookie in self.cookies:
+            data = self.cookies[session_cookie]
             data = self.api._signer.unsign(data)
             return json.loads(data)
         return {}


### PR DESCRIPTION
Cookie name for sessions is passed as an argument `session_cookie` to `API` constructor. Default value of
`session_cookie` is `Responder-Session`.  