### PR TITLE
Add WebSockets support

### DIFF
--- a/responder/api.py
+++ b/responder/api.py
@@ -130,7 +130,6 @@ class API:
     def __call__(self, scope):
         path = scope["path"]
         root_path = scope.get("root_path", "")
-        print(path, root_path, scope['type'])
 
         # Call into a submounted app, if one exists.
         for path_prefix, app in self.apps.items():
@@ -220,17 +219,11 @@ class API:
 
         :param path: The path portion of a URL, to test all known routes against.
         """
-        # if 'ws' == protocol:
-        #     routes = self.ws_routes
-        # else:
-        #     routes = self.routes
-
         for (route, route_object) in self.routes.items():
             if route_object.does_match(path, protocol):
                 return route
 
     def _prepare_cookies(self, resp):
-        # print(resp.cookies)
         if resp.cookies:
             header = " ".join([f"{k}={v}" for k, v in resp.cookies.items()])
             resp.headers["Set-Cookie"] = header

--- a/responder/api.py
+++ b/responder/api.py
@@ -335,9 +335,8 @@ class API:
         :param static: If ``True``, and no endpoint was passed, render "static/index.html", and it will become a default route.
         :param check_existing: If ``True``, an AssertionError will be raised, if the route is already defined.
         """
-        # TODO: Fix
-        if check_existing and protocol != "ws":
-            assert route not in self.routes
+        if check_existing:
+            assert not (route in self.routes and self.routes[route].protocol == protocol)
 
         if not endpoint and static:
             endpoint = self.static_response

--- a/responder/models.py
+++ b/responder/models.py
@@ -320,10 +320,20 @@ class WebSocket:
         return (await self._starlette.receive())
 
     async def content(self):
+        """Receive bytes"""
         return (await self._starlette.receive_bytes()) 
 
     async def text(self):
+        """Receive text"""
         return (await self._starlette.receive_text())
+
+    async def json(self):
+        """Receive json"""
+        return (await self._starlette.receive_json())
+
+    async def media(self):
+        """Receive json"""
+        return (await self.receive_json())
 
     async def send(self):
         await self._starlette.send()

--- a/responder/routes.py
+++ b/responder/routes.py
@@ -3,10 +3,10 @@ from parse import parse
 
 
 def memoize(f):
-    def helper(self, s):
+    def helper(self, s, *args, **kwargs):
         memoize_key = f"{f.__name__}:{s}"
         if memoize_key not in self._memo:
-            self._memo[memoize_key] = f(self, s)
+            self._memo[memoize_key] = f(self, s, *args, **kwargs)
         return self._memo[memoize_key]
 
     return helper
@@ -15,9 +15,10 @@ def memoize(f):
 class Route:
     _param_pattern = re.compile(r"{([^{}]*)}")
 
-    def __init__(self, route, endpoint):
+    def __init__(self, route, endpoint, protocol="http"):
         self.route = route
         self.endpoint = endpoint
+        self.protocol = protocol
         self._memo = {}
 
     def __repr__(self):
@@ -44,8 +45,10 @@ class Route:
         return bool(self._param_pattern.search(self.route))
 
     @memoize
-    def does_match(self, s):
+    def does_match(self, s, protocol="http"):
         if s == self.route:
+            if self.protocol != protocol:
+                return False
             return True
 
         named = self.incoming_matches(s)


### PR DESCRIPTION
I've added websocket support based on starlette, only functions are supported now, I can add classes and improve if you approve this.

In addition to the path, protocol is added now to match routes, so it's fine to have 2 routes with the same path but different protocols

```
@api.route('/ws')
def test(req, resp):
    """ Http request """
    resp.text = "Hey"

@api.ws_route('/ws')
async def hello(ws):
    await ws.accept()
    await ws.send_text("Hello via websocket!")
    await ws.close()

@api.ws_route('/{greeting}')
async def greeting(ws, greeting):
    await ws.accept()
    while True:
        name = await ws.text()
        await ws.send_text(f"{greeting} {name} via ws!")
    await ws.close()
```
