### PR TITLE
doc: fix Class-based views

### DIFF
--- a/docs/source/tour.rst
+++ b/docs/source/tour.rst
@@ -9,7 +9,7 @@ Class-based views (and setting some headers and stuff)::
 
     @api.route("/{greeting}")
     class GreetingResource:
-        def on_request(req, resp, *, greeting):   # or on_get...
+        def on_request(self, req, resp, *, greeting):   # or on_get...
             resp.text = f"{greeting}, world!"
             resp.headers.update({'X-Life': '42'})
             resp.status_code = api.status_codes.HTTP_416


### PR DESCRIPTION
In Class-based views, each method needs `self` as 1st argument.