### PR TITLE
fix resolving routes with same path but different protocols and other bugfixes

### DIFF
--- a/responder/api.py
+++ b/responder/api.py
@@ -266,7 +266,7 @@ class API:
                 except Exception:
                     self.default_response(error=True, **kwargs)
 
-            if route.is_class_based or cont:
+            elif route.is_class_based or cont:
                 try:
                     view = route.endpoint(**params)
                 except TypeError:

--- a/responder/api.py
+++ b/responder/api.py
@@ -162,7 +162,6 @@ class API:
 
     async def _dispatch_ws(self, ws):
         route = self.path_matches_route(ws.url.path, protocol="ws")
-        print("DW", route)
         route = self.routes.get(route)
         await self._dispatch(route, ws=ws)
 
@@ -227,10 +226,7 @@ class API:
 
         # Get the route.
         route = self.path_matches_route(req.url.path)
-        print("Req", route)
         route = self.routes.get(route)
-        print("Req", route)
-        print(self.routes)
 
         # Create the response object.
         resp = models.Response(req=req, formats=self.formats)
@@ -244,10 +240,8 @@ class API:
         return resp
 
     async def _dispatch(self, route, **kwargs):
-        print(route)
         cont = False
 
-        print(kwargs)
         if route:
             if "req" in kwargs:
                 params = route.incoming_matches(kwargs["req"].url.path)
@@ -270,7 +264,6 @@ class API:
                     except TypeError as e:
                         cont = True
                 except Exception:
-                    print("EEEE")
                     self.default_response(error=True, **kwargs)
 
             if route.is_class_based or cont:
@@ -289,7 +282,6 @@ class API:
                     if hasattr(r, "send"):
                         await r
                 except Exception:
-                    print("Here")
                     self.default_response(error=True, **kwargs)
 
                 # Then on_get.

--- a/responder/api.py
+++ b/responder/api.py
@@ -268,8 +268,6 @@ class API:
                         if hasattr(r, "cr_running"):
                             await r
                     except TypeError as e:
-                        print("TypeError", e)
-                        print("\n"*10)
                         cont = True
                 except Exception:
                     print("EEEE")

--- a/responder/api.py
+++ b/responder/api.py
@@ -162,6 +162,7 @@ class API:
 
     async def _dispatch_ws(self, ws):
         route = self.path_matches_route(ws.url.path, protocol="ws")
+        print("DW", route)
         route = self.routes.get(route)
         await self._dispatch(route, ws=ws)
 
@@ -243,7 +244,7 @@ class API:
         return resp
 
     async def _dispatch(self, route, **kwargs):
-
+        print(route)
         cont = False
 
         print(kwargs)
@@ -267,6 +268,8 @@ class API:
                         if hasattr(r, "cr_running"):
                             await r
                     except TypeError as e:
+                        print("TypeError", e)
+                        print("\n"*10)
                         cont = True
                 except Exception:
                     print("EEEE")

--- a/responder/routes.py
+++ b/responder/routes.py
@@ -4,16 +4,23 @@ from parse import parse
 
 def memoize(f):
     def helper(self, s, *args, **kwargs):
-        memoize_key = f"{kwargs.get('protocol', '')}:{f.__name__}:{s}"
+        memoize_key = f"{f.__name__}:{s}"
         if memoize_key not in self._memo:
             self._memo[memoize_key] = f(self, s, *args, **kwargs)
         return self._memo[memoize_key]
 
     return helper
 
+# TODO: Pass the key pattern as arg to memoize
+# TODO: Remove memoize_match
 def memoize_match(f):
     def helper(self, s, *args, **kwargs):
-        memoize_key = f"{args[0]}:{f.__name__}:{s}"
+        print(args, kwargs)
+        if len(args) > 0:
+            protocol = args[0]
+        else:
+            protocol = "http"
+        memoize_key = f"{protocol}:{f.__name__}:{s}"
         if memoize_key not in self._memo:
             self._memo[memoize_key] = f(self, s, *args, **kwargs)
         return self._memo[memoize_key]
@@ -86,6 +93,7 @@ class Route:
     def is_class_based(self):
         return hasattr(self.endpoint, "__class__")
 
+    @property
     def is_function(self):
         routed = hasattr(self.endpoint, "is_routed")
         code = hasattr(self.endpoint, "__code__")

--- a/responder/routes.py
+++ b/responder/routes.py
@@ -15,7 +15,6 @@ def memoize(f):
 # TODO: Remove memoize_match
 def memoize_match(f):
     def helper(self, s, *args, **kwargs):
-        print(args, kwargs)
         if len(args) > 0:
             protocol = args[0]
         else:

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -344,6 +344,7 @@ def test_schema_generation():
         resp.media = PetSchema().dump({"name": "little orange"})
 
     r = api.session().get("http://;/schema.yml")
+    print(r.content)
     dump = yaml.safe_load(r.content)
     print(dump)
     assert dump

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -344,9 +344,7 @@ def test_schema_generation():
         resp.media = PetSchema().dump({"name": "little orange"})
 
     r = api.session().get("http://;/schema.yml")
-    print(r.content)
     dump = yaml.safe_load(r.content)
-    print(dump)
     assert dump
     assert dump["openapi"] == "3.0"
 

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -345,7 +345,7 @@ def test_schema_generation():
 
     r = api.session().get("http://;/schema.yml")
     dump = yaml.safe_load(r.content)
-
+    print(dump)
     assert dump
     assert dump["openapi"] == "3.0"
 


### PR DESCRIPTION
This PR fix resolving routes with same path but different protocols and other cirtical bugfixes

Quick Reminder : `@api.route("/")` and `api.add_route('/', ws1, websocket=True)` are valid and the route will be resolved based on the protocol


** The `test_schema_generation` fails 