### PR TITLE
Fix Route.is_function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ coverage.xml
 
 __pycache__
 tests/__pycache__
-
+*.pyc
 build
 responder.egg-info/
 dist/

--- a/responder/routes.py
+++ b/responder/routes.py
@@ -81,7 +81,7 @@ class Route:
 
     @property
     def is_function(self):
-        routed = hasattr(self.endpoint, "is_routed")
+        is_callable = callable(self.endpoint)
         code = hasattr(self.endpoint, "__code__")
         kwdefaults = hasattr(self.endpoint, "__kwdefaults__")
-        return all((routed, code, kwdefaults))
+        return all((is_callable, code, kwdefaults))


### PR DESCRIPTION
This fix #129.

I'm not sure about the purpose of [endpoint.is_routed](https://github.com/kennethreitz/responder/blob/master/responder/api.py#L351) so I just keep it there. 