### PR TITLE
Do not return default endpoint if the route is found

### DIFF
--- a/responder/api.py
+++ b/responder/api.py
@@ -342,7 +342,7 @@ class API:
         if resp.status_code is None:
             resp.status_code = 200
 
-        if self.default_endpoint:
+        if self.default_endpoint and notfound:
             self.default_endpoint(req, resp)
         else:
             if notfound:


### PR DESCRIPTION
Based on the docs https://github.com/kennethreitz/responder/blob/master/responder/api.py#L314, the default endpoint should not render if the path is found
ref #141 