### PR TITLE
Updated 404 when static=True and no index.html

### DIFF
--- a/responder/api.py
+++ b/responder/api.py
@@ -384,6 +384,9 @@ class API:
         if os.path.exists(index):
             with open(index, "r") as f:
                 resp.text = f.read()
+        else:
+            self.default_endpoint = None
+            self.default_response(req, resp, notfound=True)
 
     def schema_response(self, req, resp):
         resp.status_code = status_codes.HTTP_200


### PR DESCRIPTION
Once again:

>Right now when static=True and there is no static/index.html file to render, the server returns 200 with a body just saying "null". I think a 404 "Not found" error in this case would be more indicative for the developer.

Improved based on the suggestion in https://github.com/kennethreitz/responder/pull/149