### PR TITLE
Improve exception handling

### DIFF
--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -3,6 +3,8 @@ import yaml
 import responder
 import io
 
+from starlette.responses import PlainTextResponse
+
 
 def test_api_basic_route(api):
     @api.route("/")
@@ -460,12 +462,18 @@ def test_file_uploads(api):
 
 
 def test_500(api):
+    def catcher(request, exc):
+        return PlainTextResponse("Suppressed error", 500)
+
+    api.app.add_exception_handler(ValueError, catcher)
+
     @api.route("/")
     def view(req, resp):
         raise ValueError
 
     r = api.requests.get(api.url_for(view))
     assert not r.ok
+    assert r.content == b'Suppressed error'
 
 
 def test_404(api):


### PR DESCRIPTION
Re-raise exceptions caught in _dispatch_request.  Added starlette ExceptionMiddleware to be able to test this gracefully.

This should make any unhandled exceptions bubble all the way up so the stack gets printed by the responder server process, and if debug is enabled, the trace is returned in the body by starlette's `get_debug_response` as far as I can tell.