### PR TITLE
fix AttributeError if headers value is int

### DIFF
--- a/responder/models.py
+++ b/responder/models.py
@@ -281,9 +281,17 @@ class Response:
     async def __call__(self, receive, send):
         body, headers = await self.body
         if self.headers:
-            headers.update(self.headers)
+            headers.update(self._validate_headers(headers))
 
         response = StarletteResponse(
             body, status_code=self.status_code, headers=headers
         )
         await response(receive, send)
+
+    @staticmethod
+    def _validate_headers(headers):
+        for key, value in headers.items():
+            if isinstance(value, int):
+                value = str(value)
+                headers[key] = value
+        return headers


### PR DESCRIPTION
In the tutorial
```
@api.route("/pizza")
def pizza_pizza(req, resp):
    resp.headers['X-Pizza'] = 42
```
will raise AttributeError
```
INFO: Started server process [31810]
INFO: Uvicorn running on http://127.0.0.1:5042 (Press CTRL+C to quit)
INFO: ('127.0.0.1', 39328) - "GET /pizza HTTP/1.1" 500
ERROR: Exception in ASGI application
Traceback (most recent call last):
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/uvicorn/protocols/http/httptools_impl.py", line 387, in run_asgi
    result = await asgi(self.receive, self.send)
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/uvicorn/middleware/message_logger.py", line 59, in __call__
    await self.inner(self.receive, self.send)
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/uvicorn/middleware/debug.py", line 80, in __call__
    await asgi(receive, self.send)
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/starlette/exceptions.py", line 68, in app
    raise exc from None
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/starlette/exceptions.py", line 60, in app
    await instance(receive, sender)
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/starlette/middleware/gzip.py", line 33, in __call__
    await self.inner(receive, self.send_with_gzip)
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/responder/api.py", line 199, in asgi
    await resp(receive, send)
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/responder/models.py", line 286, in __call__
    body, status_code=self.status_code, headers=headers
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/starlette/responses.py", line 44, in __init__
    self.init_headers(headers)
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/starlette/responses.py", line 59, in init_headers
    for k, v in headers.items()
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/starlette/responses.py", line 59, in <listcomp>
    for k, v in headers.items()
AttributeError: 'int' object has no attribute 'encode'
```
