### PR TITLE
DOC: Fix quickstart response headers

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -90,7 +90,7 @@ If you want to set a response header, like ``X-Pizza: 42``, simply modify the ``
 
     @api.route("/pizza")
     def pizza_pizza(req, resp):
-        resp.headers['X-Pizza'] = 42
+        resp.headers['X-Pizza'] = '42'
 
 That's it!
 


### PR DESCRIPTION
[starlette](https://www.starlette.io) only allow strings in response headers (see [the response docs](https://github.com/encode/starlette/blob/master/docs/responses.md) or [the code](https://github.com/encode/starlette/blob/master/starlette/responses.py#L58))

if we passing integer or boolean in response headers will raise an error
```
ERROR: Exception in ASGI application
Traceback (most recent call last):
  File "/home/repodevs/.virtualenvs/responder/lib/python3.6/site-packages/uvicorn/protocols/http/httptools_impl.py", line 387, in run_asgi
    result = await asgi(self.receive, self.send)
  File "/home/repodevs/.virtualenvs/responder/lib/python3.6/site-packages/uvicorn/middleware/message_logger.py", line 59, in __call__
    await self.inner(self.receive, self.send)
  File "/home/repodevs/.virtualenvs/responder/lib/python3.6/site-packages/starlette/exceptions.py", line 68, in app
    raise exc from None
  File "/home/repodevs/.virtualenvs/responder/lib/python3.6/site-packages/starlette/exceptions.py", line 60, in app
    await instance(receive, sender)
  File "/home/repodevs/.virtualenvs/responder/lib/python3.6/site-packages/responder/api.py", line 206, in asgi
    await resp(receive, send)
  File "/home/repodevs/.virtualenvs/responder/lib/python3.6/site-packages/responder/models.py", line 287, in __call__
    body, status_code=self.status_code, headers=headers
  File "/home/repodevs/.virtualenvs/responder/lib/python3.6/site-packages/starlette/responses.py", line 44, in __init__
    self.init_headers(headers)
  File "/home/repodevs/.virtualenvs/responder/lib/python3.6/site-packages/starlette/responses.py", line 59, in init_headers
    for k, v in headers.items()
  File "/home/repodevs/.virtualenvs/responder/lib/python3.6/site-packages/starlette/responses.py", line 59, in <listcomp>
    for k, v in headers.items()
AttributeError: 'int' object has no attribute 'encode'
```

we should mention in this docs to passing string only in headers or try fix on the starlette side?

cc: @kennethreitz @tomchristie 