### PR TITLE
DOC: change dockerfile instruction `from` to use UPPERCASE

### DIFF
--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -10,7 +10,7 @@ Assuming existing ``api.py`` and ``Pipfile.lock`` containing ``responder``.
 
 ``Dockerfile``::
 
-    from kennethreitz/pipenv
+    FROM kennethreitz/pipenv
 
     COPY . /app
     CMD python3 api.py


### PR DESCRIPTION
reference: [Dockerfile reference](https://docs.docker.com/engine/reference/builder/#format)