### PR TITLE
Trusted hosts support

### DIFF
--- a/responder/api.py
+++ b/responder/api.py
@@ -91,10 +91,10 @@ class API:
         self.cors_params = DEFAULT_CORS_PARAMS
 
         if not allowed_hosts:
-            if not debug:
-                raise RuntimeError(
-                    "You need to specify `allowed_hosts` when debug is set to False"
-                )
+            # if not debug:
+            #     raise RuntimeError(
+            #         "You need to specify `allowed_hosts` when debug is set to False"
+            #     )
             allowed_hosts = ["localhost", "127.0.0.1"]
         self.allowed_hosts = allowed_hosts
 

--- a/responder/api.py
+++ b/responder/api.py
@@ -95,7 +95,7 @@ class API:
             #     raise RuntimeError(
             #         "You need to specify `allowed_hosts` when debug is set to False"
             #     )
-            allowed_hosts = ["localhost", "127.0.0.1"]
+            allowed_hosts = ["*"]
         self.allowed_hosts = allowed_hosts
 
         # Make the static/templates directory if they don't exist.

--- a/responder/api.py
+++ b/responder/api.py
@@ -518,7 +518,7 @@ class API:
         """
 
         if self._session is None:
-            self._session = TestClient(self)
+            self._session = TestClient(self, base_url=base_url)
         return self._session
 
     def _route_for(self, endpoint):

--- a/responder/api.py
+++ b/responder/api.py
@@ -92,9 +92,10 @@ class API:
 
         if not allowed_hosts:
             if not debug:
-                raise RuntimeError("You need to specify `allowed_hosts` when debug is set to False")
-            allowed_hosts = ['localhost', '127.0.0.1']
-        allowed_hosts = ["localhost", "127.0.0.1", ";", "testserver"]
+                raise RuntimeError(
+                    "You need to specify `allowed_hosts` when debug is set to False"
+                )
+            allowed_hosts = ["localhost", "127.0.0.1"]
         self.allowed_hosts = allowed_hosts
 
         # Make the static/templates directory if they don't exist.

--- a/responder/middlewares/trustedhost.py
+++ b/responder/middlewares/trustedhost.py
@@ -1,0 +1,34 @@
+from starlette.datastructures import Headers
+from starlette.responses import PlainTextResponse
+
+def _is_trusted_host(host, allowed_hosts):
+    """
+    Check if the host matchs the pattern.
+
+    Any given pattern starting with a period is considered a wildcard pattern.
+    """
+    host = host.lower()
+    for pattern in allowed_hosts:
+        if (
+            pattern == "*" or pattern == host or
+            pattern[0] == "." and
+            (host.endswith(pattern) or host == pattern[1:])
+        ):
+            return True
+    return False
+
+class TrustedHostMiddleware:
+    def __init__(self, app, allowed_hosts):
+        self.app = app
+        self.allowed_hosts = allowed_hosts
+        self.allow_any = "*" in allowed_hosts
+
+    def __call__(self, scope):
+        if scope["type"] in ("http", "websocket") and not self.allow_any:
+            headers = Headers(scope=scope)
+            host = headers.get("host").split(":")[0]
+            print("HH", host, self.allowed_hosts)
+            print("EE", _is_trusted_host(host, self.allowed_hosts))
+            if not _is_trusted_host(host, self.allowed_hosts):
+                return PlainTextResponse("Invalid host header", status_code=400)
+        return self.app(scope)

--- a/responder/middlewares/trustedhost.py
+++ b/responder/middlewares/trustedhost.py
@@ -27,8 +27,6 @@ class TrustedHostMiddleware:
         if scope["type"] in ("http", "websocket") and not self.allow_any:
             headers = Headers(scope=scope)
             host = headers.get("host").split(":")[0]
-            print("HH", host, self.allowed_hosts)
-            print("EE", _is_trusted_host(host, self.allowed_hosts))
             if not _is_trusted_host(host, self.allowed_hosts):
                 return PlainTextResponse("Invalid host header", status_code=400)
         return self.app(scope)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def current_dir():
 
 @pytest.fixture
 def api():
-    return responder.API()
+    return responder.API(allowed_hosts=["testserver", ";"])
 
 
 @pytest.fixture

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -550,9 +550,7 @@ def test_session_thoroughly(api, session):
         resp.media = {"session": req.session}
 
     r = session.get(api.url_for(set))
-    print(r.headers)
     r = session.get(api.url_for(get))
-    print(r.request.headers)
     assert r.json() == {"session": {"hello": "world"}}
 
 def test_before_responpse(api, session):

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -536,7 +536,7 @@ def test_redirects(api, session):
     def one(req, resp):
         resp.text = "redirected"
 
-    assert session.get("/1").url == "http://testserver/1"
+    assert session.get("/1").url == "http://;/1"
 
 
 def test_session_thoroughly(api, session):

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -333,7 +333,11 @@ def test_schema_generation():
     import responder
     from marshmallow import Schema, fields
 
-    api = responder.API(title="Web Service", openapi="3.0")
+    api = responder.API(
+        title="Web Service",
+        openapi="3.0",
+        allowed_hosts=["testserver", ";"]
+    )
 
     @api.schema("Pet")
     class PetSchema(Schema):
@@ -364,7 +368,12 @@ def test_documentation():
     import responder
     from marshmallow import Schema, fields
 
-    api = responder.API(title="Web Service", openapi="3.0", docs_route="/docs")
+    api = responder.API(
+        title="Web Service",
+        openapi="3.0",
+        docs_route="/docs",
+        allowed_hosts=["testserver", ";"]
+    )
 
     @api.schema("Pet")
     class PetSchema(Schema):


### PR DESCRIPTION
I've added trusted host support for security reasons (Host header attacks) and other stuff (SAAS,...).
The host is considered valid, if it's an exact match or if it matches a wildcard pattern.

If `starlette` accepts my PR https://github.com/encode/starlette/pull/148 to extend the host validation with wildcard domains, we can remove the middleware from `responder`.