### PR TITLE
Fixed missing `.data` on Marshmallow dump

### DIFF
--- a/docs/source/tour.rst
+++ b/docs/source/tour.rst
@@ -81,7 +81,7 @@ Responder comes with built-in support for OpenAPI / marshmallow::
                     schema:
                         $ref = "#/components/schemas/Pet"
         """
-        resp.media = PetSchema().dump({"name": "little orange"})
+        resp.media = PetSchema().dump({"name": "little orange"}).data
 
 
 ::


### PR DESCRIPTION
Doc sample code was returning complete result of marshmallow schema `dump` what includes data as well as errors items.

Fixed by adding `.data` on `dump` result.