### PR TITLE
Fix OpenAPI version in examples

### DIFF
--- a/docs/source/tour.rst
+++ b/docs/source/tour.rst
@@ -61,7 +61,7 @@ Responder comes with built-in support for OpenAPI / marshmallow::
     import responder
     from marshmallow import Schema, fields
 
-    api = responder.API(title="Web Service", version="1.0", openapi="3.0")
+    api = responder.API(title="Web Service", version="1.0", openapi="3.0.0")
 
 
     @api.schema("Pet")
@@ -112,7 +112,7 @@ Interactive Documentation
 
 Responder can automatically supply API Documentation for you. Using the example above::
 
-    api = responder.API(title="Web Service", version="1.0", openapi="3.0", docs_route="/docs")
+    api = responder.API(title="Web Service", version="1.0", openapi="3.0.0", docs_route="/docs")
 
 This will make ``/docs`` render interactive documentation for your API.
 


### PR DESCRIPTION
The example for "OpenAPI Schema Support" and "Interactive Documentation had `openapi="3.0"` which would cause the following error when swagger UI tried to render the schema:
```
Unable to render this definition
The provided definition does not specify a valid version field.

Please indicate a valid Swagger or OpenAPI version field. Supported version fields are swagger: "2.0" and those that match  openapi: 3.0.n (for example, openapi: 3.0.0).
```