### PR TITLE
Fixed a typo in setup.py: mainfest -> manifest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ class DebCommand(Command):
             rmtree(os.path.join(here, "deb_dist"))
         except FileNotFoundError:
             pass
-        self.status(u"Creating debian mainfest…")
+        self.status(u"Creating debian manifest…")
         os.system(
             "python setup.py --command-packages=stdeb.command sdist_dsc -z artful --package3=pipenv --depends3=python3-virtualenv-clone"
         )


### PR DESCRIPTION
setup.py had a typo in the DebCommand class that would output "Creating debian _mainfest_"