### PR TITLE
Fix static response

### DIFF
--- a/responder/api.py
+++ b/responder/api.py
@@ -433,7 +433,7 @@ class API:
 
     def static_response(self, req, resp):
         index = (self.static_dir / "index.html").resolve()
-        resp.content = ""
+        resp.content = None
         if os.path.exists(index):
             with open(index, "r") as f:
                 resp.text = f.read()


### PR DESCRIPTION
I had an issue serving static files using `api.add_route("/", static=True)`.
In Response.body property, a check is done on the content variable using None, but response content value is set to "" static_response method, and expression `"" is not None` will always return True