### PR TITLE
Fix issue in OpenAPI Schema Support example

### DIFF
--- a/docs/source/tour.rst
+++ b/docs/source/tour.rst
@@ -81,7 +81,7 @@ Responder comes with built-in support for OpenAPI / marshmallow::
                     schema:
                         $ref = "#/components/schemas/Pet"
         """
-        resp.media = PetSchema().dump({"name": "little orange"}).data
+        resp.media = PetSchema().dump({"name": "little orange"})
 
 
 ::


### PR DESCRIPTION
`PetSchema().dump()` returns a dict. Calling `.data` on it causes an AttributeError.