### PR TITLE
Use Starlette's run_in_threadpool

### DIFF
--- a/responder/background.py
+++ b/responder/background.py
@@ -3,6 +3,7 @@ import functools
 import concurrent.futures
 import multiprocessing
 import traceback
+from starlette.concurrency import run_in_threadpool
 
 
 class BackgroundQueue:
@@ -40,6 +41,4 @@ class BackgroundQueue:
         if asyncio.iscoroutinefunction(func):
             return await asyncio.ensure_future(func(*args, **kwargs))
         else:
-            fn = functools.partial(func, *args, **kwargs)
-            loop = asyncio.get_event_loop()
-            return await loop.run_in_executor(None, fn)
+            return await run_in_threadpool(func, *args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if sys.argv[-1] == "publish":
     sys.exit()
 
 required = [
-    "starlette",
+    "starlette<0.9",
     "uvicorn",
     "aiofiles",
     "pyyaml",


### PR DESCRIPTION
I've kept this strictly focused on #211, but there's various other bits around here that look like they need sorting out too.

Bits that cropped up looking in this area:

* `__call__` is annotated as `None`, but returns results.
* It's not obvious that ` asyncio.ensure_future` should be needed here, instead of just `await func(*args, **kwargs)`.
* It's confusing that `api.py` uses `self.background(route.endpoint, req, resp, **params)`when eg. calling request handlers, since these aren't background jobs.
* It's unclear why `api.py` checks `cr_running` and optionally awaits. Just `await self.background(...)` looks right here.

(I'd like to work on resolving some of this stuff sometime, but I'd need to make a proper chunk of time first in which to make a meaningful contribution to responder)

I've also pinned Starlette here, which I think makes sense here.
