### PR TITLE
formats: format_file returns filename, data, and content-type [Breaking]

### DIFF
--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -465,13 +465,13 @@ def test_file_uploads(api):
         files = await req.media("files")
         result = {}
         result["hello"] = files["hello"]["content"].decode("utf-8")
-        result["no-name"] = files["no-name"].decode("utf-8")
+        result["not-a-file"] = files["not-a-file"].decode("utf-8")
         resp.media = {"files": result}
 
     world = io.StringIO("world")
-    data = {"hello": ("hello.txt", world, "text/plain"), "no-name": b"data only"}
+    data = {"hello": ("hello.txt", world, "text/plain"), "not-a-file": b"data only"}
     r = api.requests.post(api.url_for(upload), files=data)
-    assert r.json() == {"files": {"hello": "world", "no-name": "data only"}}
+    assert r.json() == {"files": {"hello": "world", "not-a-file": "data only"}}
 
 
 def test_500(api):

--- a/tests/test_status_codes.py
+++ b/tests/test_status_codes.py
@@ -8,7 +8,7 @@ from responder import status_codes
         pytest.param(101, True, id="Normal 101"),
         pytest.param(199, True, id="Not actual status code but within 100"),
         pytest.param(0, False, id="Zero case (below 100)"),
-        pytest.param(200, False, id="Above 100")
+        pytest.param(200, False, id="Above 100"),
     ],
 )
 def test_is_100(status_code, expected):
@@ -21,7 +21,7 @@ def test_is_100(status_code, expected):
         pytest.param(201, True, id="Normal 201"),
         pytest.param(299, True, id="Not actual status code but within 200"),
         pytest.param(0, False, id="Zero case (below 200)"),
-        pytest.param(300, False, id="Above 200")
+        pytest.param(300, False, id="Above 200"),
     ],
 )
 def test_is_200(status_code, expected):
@@ -34,7 +34,7 @@ def test_is_200(status_code, expected):
         pytest.param(301, True, id="Normal 301"),
         pytest.param(399, True, id="Not actual status code but within 300"),
         pytest.param(0, False, id="Zero case (below 300)"),
-        pytest.param(400, False, id="Above 300")
+        pytest.param(400, False, id="Above 300"),
     ],
 )
 def test_is_300(status_code, expected):
@@ -47,7 +47,7 @@ def test_is_300(status_code, expected):
         pytest.param(401, True, id="Normal 401"),
         pytest.param(499, True, id="Not actual status code but within 400"),
         pytest.param(0, False, id="Zero case (below 400)"),
-        pytest.param(500, False, id="Above 400")
+        pytest.param(500, False, id="Above 400"),
     ],
 )
 def test_is_400(status_code, expected):
@@ -57,10 +57,10 @@ def test_is_400(status_code, expected):
 @pytest.mark.parametrize(
     "status_code, expected",
     [
-        pytest.param(501, True, id="Normal 401"),
-        pytest.param(599, True, id="Not actual status code but within 400"),
-        pytest.param(0, False, id="Zero case (below 400)"),
-        pytest.param(600, False, id="Above 500")
+        pytest.param(501, True, id="Normal 501"),
+        pytest.param(599, True, id="Not actual status code but within 500"),
+        pytest.param(0, False, id="Zero case (below 500)"),
+        pytest.param(600, False, id="Above 500"),
     ],
 )
 def test_is_500(status_code, expected):


### PR DESCRIPTION
Change `format_file` behaviors. If a part of `multipart/form-data` has no `content-type`, `format_file` returns `{name : value}`.

Otherwise, it returns `{name : {"filename" : filename, "content" : data_as_binary, "content-type" : content-type}}`.