### PR TITLE
persist debug from API to run

### DIFF
--- a/responder/api.py
+++ b/responder/api.py
@@ -90,6 +90,7 @@ class API:
         self.hsts_enabled = enable_hsts
         self.cors = cors
         self.cors_params = cors_params
+        self.debug = debug
 
         if not allowed_hosts:
             # if not debug:
@@ -628,4 +629,6 @@ class API:
         spawn()
 
     def run(self, **kwargs):
+        if 'debug' not in kwargs:
+            kwargs.update({'debug': self.debug})
         self.serve(**kwargs)


### PR DESCRIPTION
Resolves #239 where the debug from the `API()` method does not persist to the `run()` method

This ensures that if the user adds debug to the API call that it persists to the run method unless overridden directly. 

``` python
api = responder.API(debug=True)
api.run()  # debug turned on for uvicorn
```

``` python 
api = responder.API(debug=True)
api.run(debug=False)  # debug turned off for uvicorn
```