### PR TITLE
Stripping right trailing slash so it won't interfere url match.

### DIFF
--- a/responder/routes.py
+++ b/responder/routes.py
@@ -45,7 +45,10 @@ class Route:
 
     @functools.lru_cache(maxsize=None)
     def incoming_matches(self, s):
-        results = parse(self.route, s)
+        results = parse(
+            self.route.rstrip('/'),
+            s.rstrip('/')
+        )
         return results.named if results else {}
 
     def url(self, **params):


### PR DESCRIPTION
If route like this created:
@api.route('/some/route/with/trailing/slash/')
it won't match following request url:
/some/route/with/trailing/slash
because of trailing slash, but with this small fix it will match.
If you have concerns with this, please, let me know.