### PR TITLE
Add monospace fallback for preformatted text in docs

### DIFF
--- a/docs/source/_templates/hacks.html
+++ b/docs/source/_templates/hacks.html
@@ -26,7 +26,7 @@
   .class em,
   .descname,
   .method em {
-    font-family: "Operator Mono SSm A", "Operator Mono SSm B" !important;
+    font-family: "Operator Mono SSm A", "Operator Mono SSm B", monospace !important;
     font-weight: 400 !important;
   }
 


### PR DESCRIPTION
Provide a fallback for when the custom fonts cant be loaded.