### PR TITLE
Fix broken exception handling in test_500

### DIFF
--- a/responder/api.py
+++ b/responder/api.py
@@ -13,7 +13,6 @@ import yaml
 from apispec import APISpec, yaml_utils
 from apispec.ext.marshmallow import MarshmallowPlugin
 from asgiref.wsgi import WsgiToAsgi
-from starlette.exceptions import ExceptionMiddleware
 from starlette.middleware.errors import ServerErrorMiddleware
 from starlette.lifespan import LifespanHandler
 from starlette.middleware.cors import CORSMiddleware
@@ -129,8 +128,6 @@ class API:
 
         self.default_endpoint = None
         self.app = self.dispatch
-        self.exception_middleware = ExceptionMiddleware(self.dispatch, debug=debug)
-        self.app = self.exception_middleware
         self.add_middleware(GZipMiddleware)
 
         if self.hsts_enabled:

--- a/responder/api.py
+++ b/responder/api.py
@@ -13,6 +13,7 @@ import yaml
 from apispec import APISpec, yaml_utils
 from apispec.ext.marshmallow import MarshmallowPlugin
 from asgiref.wsgi import WsgiToAsgi
+from starlette.exceptions import ExceptionMiddleware
 from starlette.middleware.errors import ServerErrorMiddleware
 from starlette.lifespan import LifespanHandler
 from starlette.middleware.cors import CORSMiddleware
@@ -128,6 +129,8 @@ class API:
 
         self.default_endpoint = None
         self.app = self.dispatch
+        self.exception_middleware = ExceptionMiddleware(self.dispatch, debug=debug)
+        self.app = self.exception_middleware
         self.add_middleware(GZipMiddleware)
 
         if self.hsts_enabled:

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -478,7 +478,7 @@ def test_500(api):
     def catcher(request, exc):
         return PlainTextResponse("Suppressed error", 500)
 
-    api.app.add_exception_handler(ValueError, catcher)
+    api.exception_middleware.add_exception_handler(ValueError, catcher)
 
     @api.route("/")
     def view(req, resp):

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -475,18 +475,15 @@ def test_file_uploads(api):
 
 
 def test_500(api):
-    def catcher(request, exc):
-        return PlainTextResponse("Suppressed error", 500)
-
-    api.exception_middleware.add_exception_handler(ValueError, catcher)
-
     @api.route("/")
     def view(req, resp):
         raise ValueError
 
-    r = api.requests.get(api.url_for(view))
+    dumb_client = responder.api.TestClient(api, base_url="http://;",
+                                           raise_server_exceptions=False)
+    r = dumb_client.get(api.url_for(view))
     assert not r.ok
-    assert r.content == b"Suppressed error"
+    assert r.status_code == responder.status_codes.HTTP_500
 
 
 def test_404(api):


### PR DESCRIPTION
This should fix the broken build by adding an additional hook for exception handling through Starlette's `ExceptionMiddleware`.