### PR TITLE
Add Request and Response to GraphQL context

### DIFF
--- a/docs/source/tour.rst
+++ b/docs/source/tour.rst
@@ -52,6 +52,8 @@ Serve a GraphQL API::
 
 Visiting the endpoint will render a *GraphiQL* instance, in the browser.
 
+You can make use of Responder's Request and Response objects in your GraphQL resolvers through ``info.context['request']`` and ``info.context['response']``.
+
 
 OpenAPI Schema Support
 ----------------------

--- a/responder/ext/graphql.py
+++ b/responder/ext/graphql.py
@@ -48,8 +48,9 @@ class GraphQLView:
             return
 
         query, variables, operation_name = await self._resolve_graphql_query(req)
+        context = {"request": req, "response": resp}
         result = schema.execute(
-            query, variables=variables, operation_name=operation_name
+            query, variables=variables, operation_name=operation_name, context=context
         )
         result, status_code = encode_execution_results(
             [result],


### PR DESCRIPTION
#### Reasoning
This gives GraphQL resolvers easy access to everything Responder related.

A common use case for this would be handling uploads, filtering returned fields by user permissions, requiring login for certain queries, etc.

#### Example resolver
```python
def resolve_greeting(self, info):
    username = info.context['request'].session.get('username', '')
    return f'Hello, {username}!'
```