### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if sys.argv[-1] == "publish":
     sys.exit()
 
 required = [
-    "starlette",
+    "starlette<0.10",
     "uvicorn",
     "aiofiles",
     "pyyaml",


### PR DESCRIPTION
Given that Starlette *isn't* yet at a 1.0 release, it'd make sense to keep it pinned to the current median release.