### PR TITLE
fix: always respect the configured session_cookie

### DIFF
--- a/responder/models.py
+++ b/responder/models.py
@@ -109,7 +109,7 @@ class Request:
     @property
     def session(self):
         """The session data, in dict form, from the Request."""
-        if "Responder-Session" in self.cookies:
+        if self.api.session_cookie in self.cookies:
 
             data = self.cookies[self.api.session_cookie]
 


### PR DESCRIPTION
The `session_cookie` was refactored to be set via a hardcoded `DEFAULT_SESSION_COOKIE` static variable, and this change will allow future cookie changes to trickle to the Request object.