### PR TITLE
Add resp.html property and make resp.text a property

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ Only **Python 3.6+** is supported.
 
 The primary concept here is to bring the niceties that are brought forth from both Flask and Falcon and unify them into a single framework, along with some new ideas I have. I also wanted to take some of the API primitives that are instilled in the Requests library and put them into a web framework. So, you'll find a lot of parallels here with Requests.
 
-- Setting `resp.text` sends back unicode, while setting `resp.content` sends back bytes.
-- Setting `resp.media` sends back JSON/YAML (`.text`/`.content` override this).
+- Setting `resp.content` sends back bytes.
+- Setting `resp.text` sends back unicode, while setting `resp.html` sends back HTML.
+- Setting `resp.media` sends back JSON/YAML (`.text`/`.html`/`.content` override this).
 - Case-insensitive `req.headers` dict (from Requests directly).
 - `resp.status_code`, `req.method`, `req.url`, and other familiar friends.
+
 
 ## Ideas
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -113,8 +113,9 @@ The Basic Idea
 
 The primary concept here is to bring the niceties that are brought forth from both Flask and Falcon and unify them into a single framework, along with some new ideas I have. I also wanted to take some of the API primitives that are instilled in the Requests library and put them into a web framework. So, you'll find a lot of parallels here with Requests.
 
-- Setting ``resp.text`` sends back unicode, while setting ``resp.content`` sends back bytes.
-- Setting ``resp.media`` sends back JSON/YAML (``.text``/``.content`` override this).
+- Setting ``resp.content`` sends back bytes.
+- Setting ``resp.text`` sends back unicode, while setting ``resp.html`` sends back HTML.
+- Setting ``resp.media`` sends back JSON/YAML (``.text``/``.html``/``.content`` override this).
 - Case-insensitive ``req.headers`` dict (from Requests directly).
 - ``resp.status_code``, ``req.method``, ``req.url``, and other familiar friends.
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -69,7 +69,7 @@ If you want to render a template, simply use ``api.template``. No need for addit
 
     @api.route("/hello/{who}/html")
     def hello_html(req, resp, *, who):
-        resp.content = api.template('hello.html', who=who)
+        resp.html = api.template('hello.html', who=who)
 
 The ``api`` instance is available as an object during template rendering.
 

--- a/responder/api.py
+++ b/responder/api.py
@@ -459,14 +459,14 @@ class API:
                 resp.text = "Application error."
 
     def docs_response(self, req, resp):
-        resp.text = self.docs
+        resp.html = self.docs
 
     def static_response(self, req, resp):
         index = (self.static_dir / "index.html").resolve()
         resp.content = None
         if os.path.exists(index):
             with open(index, "r") as f:
-                resp.text = f.read()
+                resp.html = f.read()
 
     def schema_response(self, req, resp):
         resp.status_code = status_codes.HTTP_200

--- a/responder/models.py
+++ b/responder/models.py
@@ -289,7 +289,7 @@ class Response:
                 headers["Content-Type"] = self.mimetype
             if self.encoding is not None:
                 headers["Encoding"] = self.encoding
-                content = self.content.encode(self.encoding)
+                content = content.encode(self.encoding)
             return (content, headers)
 
         for format in self.formats:

--- a/responder/models.py
+++ b/responder/models.py
@@ -257,9 +257,7 @@ class Response:
         "mimetype",
     ]
 
-    text = content_setter(
-        "text/plain"
-    )  #: A unicode representation of the response body.
+    text = content_setter("text/plain")
     html = content_setter("text/html")
 
     def __init__(self, req, *, formats):

--- a/responder/models.py
+++ b/responder/models.py
@@ -285,7 +285,7 @@ class Response:
             content = self.content
             if self.mimetype is not None:
                 headers["Content-Type"] = self.mimetype
-            if self.encoding is not None:
+            if self.mimetype == "text/plain" and self.encoding is not None:
                 headers["Encoding"] = self.encoding
                 content = content.encode(self.encoding)
             return (content, headers)

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -724,6 +724,7 @@ def test_response_text_property(api):
     assert r.content == b"<h1>Hello !</h1>"
     assert r.headers["Content-Type"] == "text/plain"
 
+
 def test_stream(api, session):
     async def shout_stream(who):
         for c in who.upper():

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -680,3 +680,29 @@ def test_staticfiles_custom_route(tmpdir):
     # Not found on dir listing
     r = session.get(f"{static_route}")
     assert r.status_code == api.status_codes.HTTP_404
+
+
+def test_response_html_property(api):
+    @api.route("/")
+    def view(req, resp):
+        resp.html = "<h1>Hello !</h1>"
+
+        assert resp.content == "<h1>Hello !</h1>"
+        assert resp.mimetype == "text/html"
+
+    r = api.requests.get(api.url_for(view))
+    assert r.content == b"<h1>Hello !</h1>"
+    assert r.headers["Content-Type"] == "text/html"
+
+
+def test_response_text_property(api):
+    @api.route("/")
+    def view(req, resp):
+        resp.text = "<h1>Hello !</h1>"
+
+        assert resp.content == "<h1>Hello !</h1>"
+        assert resp.mimetype == "text/plain"
+
+    r = api.requests.get(api.url_for(view))
+    assert r.content == b"<h1>Hello !</h1>"
+    assert r.headers["Content-Type"] == "text/plain"


### PR DESCRIPTION
Now `resp.text` and `resp.html` are properties and the content-type is automatically set when they are set.

```python
@api.route("/hello")
def greeting(req, resp):
    resp.html = "<h1>Hello !</h1>"
    assert resp.mimetype == "text/html"
    assert resp.content == "<h1>Hello !</h1>"
    
    resp.text = "I'm a text file"
    assert resp.mimetype == "text/plain"
    assert resp.content == "I'm a text file"
```

fixes #298