### PR TITLE
implemented rest of OpenAPI Info Object

### DIFF
--- a/docs/source/tour.rst
+++ b/docs/source/tour.rst
@@ -63,7 +63,28 @@ Responder comes with built-in support for OpenAPI / marshmallow::
     import responder
     from marshmallow import Schema, fields
 
-    api = responder.API(title="Web Service", version="1.0", openapi="3.0.0")
+    description = "This is a sample server for a pet store."
+    terms_of_service = "http://example.com/terms/"
+    contact = {
+        "name": "API Support",
+        "url": "http://www.example.com/support",
+        "email": "support@example.com",
+    }
+    license = {
+        "name": "Apache 2.0",
+        "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+    }
+
+    api = responder.API(
+        title="Web Service",
+        version="1.0",
+        openapi="3.0.2",
+        docs_route='/docs',
+        description=description,
+        terms_of_service=terms_of_service,
+        contact=contact,
+        license=license,
+    )
 
 
     @api.schema("Pet")

--- a/responder/api.py
+++ b/responder/api.py
@@ -48,16 +48,10 @@ class API:
         :param enable_hsts: If ``True``, send all responses to HTTPS URLs.
         :param title: The title of the application (OpenAPI Info Object)
         :param version: The version of the OpenAPI document (OpenAPI Info Object)
-        :param contact: The contact dictionary of the application (OpenAPI Contact Object)
-                    e.g. {
-                          "name": "API Support",
-                          "url": "http://www.example.com/support",
-                          "email": "support@example.com"
-                          }
-        :param license: The license information of the exposed API (OpenAPI License Object)
-                    e.g. {"name": "Apache 2.0",
-                          "url": "https://www.apache.org/licenses/LICENSE-2.0.html"}
+        :param description: The description of the OpenAPI document (OpenAPI Info Object)
         :param terms_of_service: A URL to the Terms of Service for the API (OpenAPI Info Object)
+        :param contact: The contact dictionary of the application (OpenAPI Contact Object)
+        :param license: The license information of the exposed API (OpenAPI License Object)
     """
 
     status_codes = status_codes
@@ -68,10 +62,10 @@ class API:
         debug=False,
         title=None,
         version=None,
-        contact=None,
-        license=None,
         description=None,
         terms_of_service=None,
+        contact=None,
+        license=None,
         openapi=None,
         openapi_route="/schema.yml",
         static_dir="static",
@@ -90,10 +84,10 @@ class API:
         self.secret_key = secret_key
         self.title = title
         self.version = version
-        self.contact = contact
-        self.license = license
         self.description = description
         self.terms_of_service = terms_of_service
+        self.contact = contact
+        self.license = license
         self.openapi_version = openapi
         self.static_dir = Path(os.path.abspath(static_dir))
         self.static_route = f"/{static_route.strip('/')}"
@@ -197,14 +191,14 @@ class API:
     def _apispec(self):
 
         info = {}
-        if self.contact is not None:
-            info["contact"] = self.contact
-        if self.license is not None:
-            info["license"] = self.license
         if self.description is not None:
             info["description"] = self.description
         if self.terms_of_service is not None:
             info["termsOfService"] = self.terms_of_service
+        if self.contact is not None:
+            info["contact"] = self.contact
+        if self.license is not None:
+            info["license"] = self.license
 
         spec = APISpec(
             title=self.title,

--- a/responder/api.py
+++ b/responder/api.py
@@ -211,7 +211,7 @@ class API:
             version=self.version,
             openapi_version=self.openapi_version,
             plugins=[MarshmallowPlugin()],
-            info=info
+            info=info,
         )
 
         for route in self.routes:

--- a/responder/api.py
+++ b/responder/api.py
@@ -57,7 +57,7 @@ class API:
         :param license: The license information of the exposed API (OpenAPI License Object)
                     e.g. {"name": "Apache 2.0",
                           "url": "https://www.apache.org/licenses/LICENSE-2.0.html"}
-        :param termsOfService: A URL to the Terms of Service for the API (OpenAPI Info Object)
+        :param terms_of_service: A URL to the Terms of Service for the API (OpenAPI Info Object)
     """
 
     status_codes = status_codes
@@ -71,7 +71,7 @@ class API:
         contact=None,
         license=None,
         description=None,
-        termsOfService=None,
+        terms_of_service=None,
         openapi=None,
         openapi_route="/schema.yml",
         static_dir="static",
@@ -93,7 +93,7 @@ class API:
         self.contact = contact
         self.license = license
         self.description = description
-        self.termsOfService = termsOfService
+        self.terms_of_service = terms_of_service
         self.openapi_version = openapi
         self.static_dir = Path(os.path.abspath(static_dir))
         self.static_route = f"/{static_route.strip('/')}"
@@ -197,14 +197,14 @@ class API:
     def _apispec(self):
 
         info = {}
-        if self.contact:
+        if self.contact is not None:
             info["contact"] = self.contact
-        if self.license:
+        if self.license is not None:
             info["license"] = self.license
-        if self.description:
+        if self.description is not None:
             info["description"] = self.description
-        if self.termsOfService:
-            info["termsOfService"] = self.termsOfService
+        if self.terms_of_service is not None:
+            info["termsOfService"] = self.terms_of_service
 
         spec = APISpec(
             title=self.title,

--- a/responder/api.py
+++ b/responder/api.py
@@ -46,6 +46,18 @@ class API:
         :param templates_dir: The directory to use for templates. Will be created for you if it doesn't already exist.
         :param auto_escape: If ``True``, HTML and XML templates will automatically be escaped.
         :param enable_hsts: If ``True``, send all responses to HTTPS URLs.
+        :param title->str: The title of the application (OpenAPI Info Object)
+        :param version->str: The version of the OpenAPI document (OpenAPI Info Object)
+        :param contact->dict: The contact dictionary of the application (OpenAPI Contact Object)
+                    e.g. {
+                          "name": "API Support",
+                          "url": "http://www.example.com/support",
+                          "email": "support@example.com"
+                          }
+        :param license->dict: The license information of the exposed API (OpenAPI License Object)
+                    e.g. {"name": "Apache 2.0",
+                          "url": "https://www.apache.org/licenses/LICENSE-2.0.html"}
+        :param termsOfService->str: A URL to the Terms of Service for the API (OpenAPI Info Object)
     """
 
     status_codes = status_codes
@@ -56,6 +68,10 @@ class API:
         debug=False,
         title=None,
         version=None,
+        contact=None,
+        license=None,
+        description=None,
+        termsOfService=None,
         openapi=None,
         openapi_route="/schema.yml",
         static_dir="static",
@@ -74,6 +90,10 @@ class API:
         self.secret_key = secret_key
         self.title = title
         self.version = version
+        self.contact = contact
+        self.license = license
+        self.description = description
+        self.termsOfService = termsOfService
         self.openapi_version = openapi
         self.static_dir = Path(os.path.abspath(static_dir))
         self.static_route = f"/{static_route.strip('/')}"
@@ -175,11 +195,23 @@ class API:
 
     @property
     def _apispec(self):
+
+        info = {}
+        if self.contact:
+            info["contact"] = self.contact
+        if self.license:
+            info["license"] = self.license
+        if self.description:
+            info["description"] = self.description
+        if self.termsOfService:
+            info["termsOfService"] = self.termsOfService
+
         spec = APISpec(
             title=self.title,
             version=self.version,
             openapi_version=self.openapi_version,
             plugins=[MarshmallowPlugin()],
+            info=info
         )
 
         for route in self.routes:

--- a/responder/api.py
+++ b/responder/api.py
@@ -46,18 +46,18 @@ class API:
         :param templates_dir: The directory to use for templates. Will be created for you if it doesn't already exist.
         :param auto_escape: If ``True``, HTML and XML templates will automatically be escaped.
         :param enable_hsts: If ``True``, send all responses to HTTPS URLs.
-        :param title->str: The title of the application (OpenAPI Info Object)
-        :param version->str: The version of the OpenAPI document (OpenAPI Info Object)
-        :param contact->dict: The contact dictionary of the application (OpenAPI Contact Object)
+        :param title: The title of the application (OpenAPI Info Object)
+        :param version: The version of the OpenAPI document (OpenAPI Info Object)
+        :param contact: The contact dictionary of the application (OpenAPI Contact Object)
                     e.g. {
                           "name": "API Support",
                           "url": "http://www.example.com/support",
                           "email": "support@example.com"
                           }
-        :param license->dict: The license information of the exposed API (OpenAPI License Object)
+        :param license: The license information of the exposed API (OpenAPI License Object)
                     e.g. {"name": "Apache 2.0",
                           "url": "https://www.apache.org/licenses/LICENSE-2.0.html"}
-        :param termsOfService->str: A URL to the Terms of Service for the API (OpenAPI Info Object)
+        :param termsOfService: A URL to the Terms of Service for the API (OpenAPI Info Object)
     """
 
     status_codes = status_codes

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -336,7 +336,7 @@ def test_schema_generation():
     from marshmallow import Schema, fields
 
     api = responder.API(
-        title="Web Service", openapi="3.0", allowed_hosts=["testserver", ";"]
+        title="Web Service", openapi="3.0.2", allowed_hosts=["testserver", ";"]
     )
 
     @api.schema("Pet")
@@ -361,17 +361,34 @@ def test_schema_generation():
     dump = yaml.safe_load(r.content)
 
     assert dump
-    assert dump["openapi"] == "3.0"
+    assert dump["openapi"] == "3.0.2"
 
 
 def test_documentation():
     import responder
     from marshmallow import Schema, fields
 
+    description = "This is a sample server for a pet store."
+    terms_of_service = "http://example.com/terms/"
+    contact = {
+        "name": "API Support",
+        "url": "http://www.example.com/support",
+        "email": "support@example.com",
+    }
+    license = {
+        "name": "Apache 2.0",
+        "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+    }
+
     api = responder.API(
         title="Web Service",
-        openapi="3.0",
+        version="1.0",
+        openapi="3.0.2",
         docs_route="/docs",
+        description=description,
+        terms_of_service=terms_of_service,
+        contact=contact,
+        license=license,
         allowed_hosts=["testserver", ";"],
     )
 


### PR DESCRIPTION
This pull request address issue https://github.com/kennethreitz/responder/issues/242

I have implemented the rest of the OpenAPI Info Object, added to the doc strings of the responder.api object, and updated the _apispec function.

I copied the names of the OpenAPI object exactly per https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#infoObject

I wasn't sure of your (the maintainers) preference on what to include in the docstring for the responder.api object. I figured it was fair to add information regarding the OpenAPI parameters, include the examples, and direct users that these variables map to the OpenAPI objects.  I went back and forth on if the examples were duplication, so if there are examples added to https://github.com/kennethreitz/responder/tree/master/examples, the docstring examples are probably redundant and misplaced.

Let me know if you like or dislike the typehinting in the doc strings. I am not sure if there is a convention there, but thought it was useful.

Thanks and please let me know if there is any updates you would like.