### PR TITLE
Refactor before_requests and websockets

### DIFF
--- a/docs/source/tour.rst
+++ b/docs/source/tour.rst
@@ -235,11 +235,18 @@ Using ``before_request``
 
 If you'd like a view to be executed before every request, simply do the following::
 
-    @api.route(before_request=True)
+    @api.before_request()
     def prepare_response(req, resp):
         resp.headers["X-Pizza"] = "42"
 
 Now all requests to your HTTP Service will include an ``X-Pizza`` header.
+
+For ``websockets``::
+
+    @api.before_request(websocket=True)
+    def prepare_response(ws):
+        await ws.accept()
+
 
 WebSocket Support
 -----------------

--- a/responder/api.py
+++ b/responder/api.py
@@ -179,6 +179,16 @@ class API:
         start_response("404 NOT FOUND", [("Content-Type", "text/plain")])
         return [b"Not Found."]
 
+    def before_request(self, websocket=False):
+        def decorator(f):
+            if websocket:
+                self.before_requests.setdefault("ws", []).append(f)
+            else:
+                self.before_requests.setdefault("http", []).append(f)
+            return f
+
+        return decorator
+
     @property
     def before_http_requests(self):
         return self.before_requests.get("http", [])

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -568,6 +568,27 @@ def test_websockets_json(api):
         assert data == payload
 
 
+def test_before_websockets(api):
+    payload = {"Hello": "via websocket!"}
+
+    @api.route("/ws", websocket=True)
+    async def websocket(ws):
+        await ws.send_json(payload)
+        await ws.close()
+
+    @api.route(before_request=True, websocket=True)
+    async def before_request(ws):
+        await ws.accept()
+        await ws.send_json({"before": "request"})
+
+    client = StarletteTestClient(api)
+    with client.websocket_connect("ws://;/ws") as websocket:
+        data = websocket.receive_json()
+        assert data == {"before": "request"}
+        data = websocket.receive_json()
+        assert data == payload
+
+
 def test_startup(api):
     who = [None]
 


### PR DESCRIPTION
- Refactor websockets and before_requests.
- Add before_requests for websockets `@api.before_request(websocket=True)` `@api.route(before_request=True, websocket=True)`.
```python
@api.before_request(websocket=True)
async def before_request(ws):
    await ws.accept()
    await ws.send_text("accepted")

@api.route('/ws', websocket=True)
async def websocket(ws):
    while True:
        name = await ws.receive_text()
        await ws.send_text(f"Hello {name}!")
    await ws.close()

```
