### PR TITLE
Fix #303

### DIFF
--- a/responder/api.py
+++ b/responder/api.py
@@ -139,7 +139,10 @@ class API:
 
             self.whitenoise.add_files(
                 (
-                    Path(apistar.__file__).parent / "themes" / self.docs_theme / "static"
+                    Path(apistar.__file__).parent
+                    / "themes"
+                    / self.docs_theme
+                    / "static"
                 ).resolve()
             )
 
@@ -511,7 +514,7 @@ class API:
         resp.html = self.docs
 
     def static_response(self, req, resp):
-        
+
         assert self.static_dir is not None
 
         index = (self.static_dir / "index.html").resolve()

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -743,15 +743,12 @@ def test_staticfiles(tmpdir):
 
 def test_staticfiles_custom_route(tmpdir):
     static_dir = tmpdir.mkdir("static")
-    static_route = "custom/static/route/"
+    static_route = "/custom/static/route"
 
     asset = create_asset(static_dir)
 
     api = responder.API(static_dir=str(static_dir), static_route=static_route)
     session = api.session()
-
-    # Check
-    assert api.static_route == "/custom/static/route"
 
     static_route = api.static_route
 
@@ -764,6 +761,48 @@ def test_staticfiles_custom_route(tmpdir):
     assert r.status_code == api.status_codes.HTTP_404
 
     # Not found on dir listing
+    r = session.get(f"{static_route}")
+    assert r.status_code == api.status_codes.HTTP_404
+
+
+def test_staticfiles_none_dir(tmpdir):
+    api = responder.API(static_dir=None)
+    session = api.session()
+
+    static_dir = tmpdir.mkdir("static")
+
+    asset = create_asset(static_dir)
+
+    static_route = api.static_route
+
+    # ok
+    r = session.get(f"{static_route}/{asset.basename}")
+    assert r.status_code == api.status_codes.HTTP_404
+
+    # dir listing
+    r = session.get(f"{static_route}")
+    assert r.status_code == api.status_codes.HTTP_404
+
+    # SPA
+    with pytest.raises(Exception) as excinfo:
+        api.add_route("/spa", static=True)
+
+
+def test_staticfiles_none_dir_route(tmpdir):
+    api = responder.API(static_dir=None, static_route=None)
+    session = api.session()
+
+    static_dir = tmpdir.mkdir("static")
+
+    asset = create_asset(static_dir)
+
+    static_route = api.static_route
+
+    # ok
+    r = session.get(f"{static_route}/{asset.basename}")
+    assert r.status_code == api.status_codes.HTTP_404
+
+    # dir listing
     r = session.get(f"{static_route}")
     assert r.status_code == api.status_codes.HTTP_404
 


### PR DESCRIPTION
- Disable static files serving when `static_dir` is None.
- If `static_route` is None, `static_dir` becomes the new static route.
- Mkdir only if `static_dir` or `templates_dir` are not None. 

fixes #303 