### PR TITLE
Update tour.rst to be openapi compliant

### DIFF
--- a/docs/source/tour.rst
+++ b/docs/source/tour.rst
@@ -100,8 +100,10 @@ Responder comes with built-in support for OpenAPI / marshmallow::
             responses:
                 200:
                     description: A pet to be returned
-                    schema:
-                        $ref = "#/components/schemas/Pet"
+                    content:  
+                        application/json: 
+                            schema: 
+                                $ref: '#/components/schemas/Pet'                         
         """
         resp.media = PetSchema().dump({"name": "little orange"})
 


### PR DESCRIPTION
The current example docstrings lead to an openapi specification that returns a couple of errors, here's what I believe to be the correct implementation (which ensures that the response object is linked in the documentation).