### PR TITLE
Route params convertors

### DIFF
--- a/responder/routes.py
+++ b/responder/routes.py
@@ -1,7 +1,22 @@
 import re
 import functools
 import inspect
-from parse import parse
+from parse import parse, with_pattern
+
+
+def _make_convertor(type, pattern):
+    @with_pattern(pattern)
+    def inner(value):
+        return type(value)
+
+    return inner
+
+
+_convertors = {
+    "int": _make_convertor(int, r"\d+"),
+    "str": _make_convertor(str, r"[^/]+"),
+    "float": _make_convertor(float, r"\d+(.\d+)?"),
+}
 
 
 class Route:
@@ -46,7 +61,7 @@ class Route:
 
     @functools.lru_cache(maxsize=None)
     def incoming_matches(self, s):
-        results = parse(self.route, s)
+        results = parse(self.route, s, _convertors)
         return results.named if results else {}
 
     def url(self, **params):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -131,3 +131,30 @@ def test_does_match_with_route(route, match, expected):
 def test_weight(path_param, expected_weight):
     r = routes.Route(path_param, "test_endpoint")
     assert r._weight() == expected_weight
+
+
+@pytest.mark.parametrize(
+    "route, path, expected_result",
+    [
+        pytest.param("/{greetings:str}", "/hello", {"greetings": "hello"}),
+        pytest.param(
+            "/{greetings:str}/{who}",
+            "/hello/Laidia",
+            {"greetings": "hello", "who": "Laidia"},
+        ),
+        pytest.param("/{birth_date:int}", "/1937", {"birth_date": 1937}),
+        pytest.param(
+            "/{name:str}/{age:int}", "/Fatna/80", {"name": "Fatna", "age": 80}
+        ),
+        pytest.param(
+            "/{x:float}/{y:float}", "/10.20/75", {"x": float(10.20), "y": float(75)}
+        ),
+        pytest.param("/{name:str}/{age:int}", "/Fatna/eighty", {}),
+        pytest.param("/{greetings:int}", "/hello", {}),
+        pytest.param("/{name:float}", "/Fatna", {}),
+    ],
+)
+def test_custom_specifiers(route, path, expected_result):
+    r = routes.Route(route, "test_endpoint")
+    print(r.incoming_matches(path))
+    assert r.incoming_matches(path) == expected_result


### PR DESCRIPTION
ref #322 

Valid specifiers : int, float, str

```python
@api.route("/{name:str}/{age:int}/{weight:float}")
async def home(req, resp, *, name, age, weight):
    resp.text = f"{name}: {age} - {weight} !"
```