### PR TITLE
Update tour.rst to add quotes around hostnames

### DIFF
--- a/docs/source/tour.rst
+++ b/docs/source/tour.rst
@@ -344,7 +344,7 @@ A 400 response will be raised, if a request does not match any of the provided p
 
 ::
 
-    api = responder.API(allowed_hosts=[example.com, tenant.example.com])
+    api = responder.API(allowed_hosts=['example.com', 'tenant.example.com'])
 
 * ``allowed_hosts`` - A list of allowed hostnames. 
 


### PR DESCRIPTION
The API call in the Trusted Hosts section needs quotes around the hostnames in the example.