### PR TITLE
Add python3.7 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
+# travis use trusty by default
+dist: xenial
+
 language: python
 python:
-  - "3.6"
+  - 3.6
+  - 3.7
 
 # command to install dependencies
 install:
-  - "pip install pipenv --upgrade-strategy=only-if-needed"
-  - "pipenv install --dev"
+  - pip install pipenv --upgrade-strategy=only-if-needed
+  - pipenv install --dev
 
 # command to run the dependencies
 script:
-  - "black responder tests setup.py --check"
-  - "pytest"
+  - black responder tests setup.py --check
+  - pytest


### PR DESCRIPTION
Hi,

This `PR` aims to add `python` **3.7** on `CI`

As specified in https://github.com/kennethreitz/responder/issues/368, `classifiers` in `setup.py` suggests that `responder` could run on **3.6** and **3.7**, this `PR` avoid breaking changes on any of those versions

Regards,