### PR TITLE
Specify constraint for python version in pipenv

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,7 +17,7 @@ marshmallow = "*"
 pytest-cov = "*"
 
 [requires]
-python_version = "3.7"
+python_version = ">=3.6"
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile
+++ b/Pipfile
@@ -16,8 +16,5 @@ sphinx = "*"
 marshmallow = "*"
 pytest-cov = "*"
 
-[requires]
-python_version = ">=3.6"
-
 [pipenv]
 allow_prereleases = true


### PR DESCRIPTION
Hi,

This `PR` closes https://github.com/kennethreitz/responder/issues/368.

It specify a more flexible contraint in `Pipfile`.

Before, the constraint was strict to `python` **3.7**.

Regards,