### PR TITLE
Encouraging use of stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ See [the documentation's feature tour](https://python-responder.org/en/latest/to
 
 # Installing Responder
 
-Install the latest release:
+Install the stable release:
 
 
-    $ pipenv install responder --pre
+    $ pipenv install responder
     ✨🍰✨
 
 

--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -31,7 +31,7 @@ The basics::
 
 Install Responder::
 
-    $ pipenv install responder --pre
+    $ pipenv install responder
     ...
 
 Write out an ``api.py``::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -103,7 +103,7 @@ Installing Responder
 
 .. code-block:: shell
 
-    $ pipenv install responder --pre
+    $ pipenv install responder
     ✨🍰✨
 
 Only **Python 3.6+** is supported.


### PR DESCRIPTION
Removing the --pre flag. 

I can add another section with the original text referring to "latest" if you want.