### PR TITLE
WIP - Schema validation support for Pydantic and Marshmellow

### DIFF
--- a/examples/input_validation.py
+++ b/examples/input_validation.py
@@ -1,8 +1,9 @@
 import time
+
 from marshmallow import Schema, fields
 from pydantic import BaseModel
-import responder
 
+import responder
 
 description = "This is a sample server for a pet store."
 terms_of_service = "http://example.com/terms/"

--- a/examples/input_validation.py
+++ b/examples/input_validation.py
@@ -1,0 +1,79 @@
+import time
+from marshmallow import Schema, fields
+from pydantic import BaseModel
+import responder
+
+
+description = "This is a sample server for a pet store."
+terms_of_service = "http://example.com/terms/"
+contact = {
+    "name": "API Support",
+    "url": "http://www.example.com/support",
+    "email": "support@example.com",
+}
+license = {
+    "name": "Apache 2.0",
+    "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+}
+
+api = responder.API(
+    title="Web Service",
+    version="1.0",
+    openapi="3.0.2",
+    docs_route="/docs",
+    description=description,
+    terms_of_service=terms_of_service,
+    contact=contact,
+    license=license,
+    api_theme="elements",
+)
+
+
+@api.schema("PydanticBookCreate")
+class PydanticBookSchema(BaseModel):
+    price: float
+    title: str
+
+
+@api.schema("BookCreate")
+class MarshmallowBookSchema(Schema):
+    price = fields.Float()
+    title = fields.Str()
+
+
+@api.route("/pybook")
+@api.trust(PydanticBookSchema)
+async def pydantic_create(req, resp, *, data):
+    "Create Pydantic book"
+
+    @api.background.task
+    def process_book(book):
+        time.sleep(2)
+        print(book)
+
+    process_book(data)
+    resp.media = {"msg": "created"}
+
+
+@api.route("/marshbook")
+@api.trust(MarshmallowBookSchema)
+async def marshmallow_create(req, resp, *, data):
+    "Create create marshmallow book"
+
+    @api.background.task
+    def process_book(book):
+        time.sleep(2)
+        print(book)
+
+    process_book(data)
+    resp.media = {"msg": "created"}
+
+
+# Let's make an HTTP request to the server, to test it out.'}
+r = api.requests.post("http://;/pybook", json={"price": 9.99, "title": "Pydantic book"})
+print(r.text)
+
+r = api.requests.post(
+    "http://;/marshbook", json={"price": 10.99, "title": "Marshmallow book"}
+)
+print(r.text)

--- a/responder/api.py
+++ b/responder/api.py
@@ -1,5 +1,5 @@
-from functools import wraps
 import os
+from functools import wraps
 from pathlib import Path
 
 import marshmallow

--- a/responder/ext/schema/__init__.py
+++ b/responder/ext/schema/__init__.py
@@ -81,7 +81,10 @@ class Schema:
                 spec.path(path=route.route, operations=operations)
 
         for name, schema in self.schemas.items():
-            spec.components.schema(name, schema=schema)
+            if hasattr(schema, "schema"):
+                spec.components.schema(name, schema.schema())  # Pydantic
+            else:
+                spec.components.schema(name, schema=schema)  # Marshmallow
 
         return spec
 


### PR DESCRIPTION
check `examples/schema_input_validation.py`

"""Decorator for parsing and validating input schema.
   Supports both Pydantic and Marshmallow.

Usage::
    import time

    from pydantic import BaseModel
    import responder

    class Item(BaseModel)
        name: str

    api = responder.API()

    @api.route("/create")
    @api.trust(Item)
    def create_item(req, resp, *, data):
        @api.background.task
        def process_item(item):
            time.sleep(2)
            print(item)   # e.g {"name": "Monster Hunter"}

        process_item(data)
        resp.media = {"msg": "created"}
"""
