### PR TITLE
Endpoint request methods

### DIFF
--- a/examples/endpoint_request_methods.py
+++ b/examples/endpoint_request_methods.py
@@ -1,0 +1,35 @@
+import responder
+
+api = responder.API()
+
+
+@api.route("/{greeting}")
+async def greet(req, resp, *, greeting):  # defaults to get.
+    resp.text = f"GET - {greeting}, world!"
+
+
+@api.route("/me/{greeting}", methods=["POST"])
+async def greet_me(req, resp, *, greeting):
+    resp.text = f"POST - {greeting}, world!"
+
+
+@api.route("/class/{greeting}")
+class GreetingResource:
+    def on_get(self, req, resp, *, greeting):
+        resp.text = f"GET class - {greeting}, world!"
+        resp.headers.update({"X-Life": "42"})
+        resp.status_code = api.status_codes.HTTP_416
+
+    def on_post(self, req, resp, *, greeting):
+        resp.text = f"POST class - {greeting}, world!"
+        resp.headers.update({"X-Life": "42"})
+        resp.status_code = api.status_codes.HTTP_416
+
+    def on_request(self, req, resp, *, greeting):  # any request method.
+        resp.text = f"any class - {greeting}, world!"
+        resp.headers.update({"X-Life": "42"})
+        resp.status_code = api.status_codes.HTTP_416
+
+
+if __name__ == "__main__":
+    api.run()

--- a/examples/endpoint_request_methods.py
+++ b/examples/endpoint_request_methods.py
@@ -4,7 +4,7 @@ api = responder.API()
 
 
 @api.route("/{greeting}")
-async def greet(req, resp, *, greeting):  # all request methods.
+async def greet(req, resp, *, greeting):  # any request method.
     resp.text = f"{greeting}, world!"
 
 
@@ -24,7 +24,7 @@ class GreetingResource:
         resp.text = f"POST class - {greeting}, world!"
         resp.headers.update({"X-Life": "42"})
 
-    def on_request(self, req, resp, *, greeting):  # all request methods.
+    def on_request(self, req, resp, *, greeting):  # any request method.
         resp.text = f"any class - {greeting}, world!"
         resp.headers.update({"X-Life": "42"})
 

--- a/examples/endpoint_request_methods.py
+++ b/examples/endpoint_request_methods.py
@@ -4,8 +4,8 @@ api = responder.API()
 
 
 @api.route("/{greeting}")
-async def greet(req, resp, *, greeting):  # defaults to get.
-    resp.text = f"GET - {greeting}, world!"
+async def greet(req, resp, *, greeting):  # all request methods.
+    resp.text = f"{greeting}, world!"
 
 
 @api.route("/me/{greeting}", methods=["POST"])
@@ -18,17 +18,15 @@ class GreetingResource:
     def on_get(self, req, resp, *, greeting):
         resp.text = f"GET class - {greeting}, world!"
         resp.headers.update({"X-Life": "42"})
-        resp.status_code = api.status_codes.HTTP_416
+        resp.status_code = api.status_codes.HTTP_201
 
     def on_post(self, req, resp, *, greeting):
         resp.text = f"POST class - {greeting}, world!"
         resp.headers.update({"X-Life": "42"})
-        resp.status_code = api.status_codes.HTTP_416
 
-    def on_request(self, req, resp, *, greeting):  # any request method.
+    def on_request(self, req, resp, *, greeting):  # all request methods.
         resp.text = f"any class - {greeting}, world!"
         resp.headers.update({"X-Life": "42"})
-        resp.status_code = api.status_codes.HTTP_416
 
 
 if __name__ == "__main__":

--- a/responder/api.py
+++ b/responder/api.py
@@ -189,7 +189,7 @@ class API:
         check_existing=True,
         websocket=False,
         before_request=False,
-        methods=("GET",),
+        methods=(),
     ):
         """Adds a route to the API.
 

--- a/responder/api.py
+++ b/responder/api.py
@@ -189,6 +189,7 @@ class API:
         check_existing=True,
         websocket=False,
         before_request=False,
+        methods=("GET",),
     ):
         """Adds a route to the API.
 
@@ -212,6 +213,7 @@ class API:
             websocket=websocket,
             before_request=before_request,
             check_existing=check_existing,
+            methods=methods,
         )
 
     async def _static_response(self, req, resp):

--- a/responder/routes.py
+++ b/responder/routes.py
@@ -56,7 +56,7 @@ class BaseRoute:
 
 
 class Route(BaseRoute):
-    def __init__(self, route, endpoint, *, before_request=False, methods=("GET",)):
+    def __init__(self, route, endpoint, *, before_request=False, methods=()):
         assert route.startswith("/"), "Route path must start with '/'"
         self.route = route
         self.endpoint = endpoint
@@ -124,7 +124,9 @@ class Route(BaseRoute):
                 if on_request is None:
                     raise HTTPException(status_code=status_codes.HTTP_405) from None
         else:
-            if request.method not in [method.lower() for method in self.methods]:
+            if self.methods and request.method not in [
+                method.lower() for method in self.methods
+            ]:
                 raise HTTPException(status_code=status_codes.HTTP_405) from None
             views.append(self.endpoint)
 
@@ -228,12 +230,13 @@ class Router:
         websocket=False,
         before_request=False,
         check_existing=False,
-        methods=("GET",),
+        methods=(),
     ):
         """Adds a route to the router.
         :param route: A string representation of the route
         :param endpoint: The endpoint for the route -- can be callable, or class.
         :param default: If ``True``, all unknown requests will route to this view.
+        :param methods: A list of supported request methods for this endpoint.
         """
         if before_request:
             if websocket:


### PR DESCRIPTION
In this update, I propose an enhancement to annotate endpoints with their accepted request types, such as "POST", "GET", "PUT", and others. The intention is to ensure appropriate handling of errors when the incoming request method does not match the expected method for an endpoint. If an endpoint lacks annotations, it defaults to accepting any request method. It's important to note that the current version of Responder only supports this functionality within class-based views.

For instance, leveraging the annotation approach:

`@api.route("/", methods=["POST"])`

This enhancement streamlines the handling of request methods, promoting more explicit endpoint definition and ensuring accurate request handling within the Responder framework.

See other examples in the `examples/enpoint_request_methods.py` file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Expanded API capabilities with new route handlers for various HTTP methods.
  - Introduced asynchronous request handling for improved performance.
  - Implemented a `GreetingResource` class to manage greeting-related routes.

- **Enhancements**
  - Updated the `add_route` function to support specifying HTTP methods.

- **Tests**
  - Added tests for new endpoint request methods and route handling.

- **Documentation**
  - Adjusted documentation to reflect the new usage of HTTP methods in route declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->