### PR TITLE
Replace api theme variable 

### DIFF
--- a/examples/response_validation.py
+++ b/examples/response_validation.py
@@ -28,9 +28,8 @@ api = responder.API(
     terms_of_service=terms_of_service,
     contact=contact,
     license=license,
-    api_theme="elements",
+    openapi_theme="elements",
 )
-
 
 class Base(DeclarativeBase):
     pass

--- a/examples/response_validation.py
+++ b/examples/response_validation.py
@@ -31,6 +31,7 @@ api = responder.API(
     openapi_theme="elements",
 )
 
+
 class Base(DeclarativeBase):
     pass
 

--- a/examples/schema_validation.py
+++ b/examples/schema_validation.py
@@ -26,7 +26,7 @@ api = responder.API(
     terms_of_service=terms_of_service,
     contact=contact,
     license=license,
-    api_theme="elements",
+    openapi_theme="elements",
 )
 
 

--- a/responder/api.py
+++ b/responder/api.py
@@ -23,7 +23,7 @@ from .ext.schema import Schema as OpenAPISchema
 from .formats import get_formats
 from .routes import Router
 from .staticfiles import StaticFiles
-from .statics import DEFAULT_OPENAPI_THEME, DEFAULT_CORS_PARAMS, DEFAULT_SECRET_KEY
+from .statics import DEFAULT_CORS_PARAMS, DEFAULT_OPENAPI_THEME, DEFAULT_SECRET_KEY
 from .templates import Templates
 
 

--- a/responder/api.py
+++ b/responder/api.py
@@ -23,7 +23,7 @@ from .ext.schema import Schema as OpenAPISchema
 from .formats import get_formats
 from .routes import Router
 from .staticfiles import StaticFiles
-from .statics import DEFAULT_API_THEME, DEFAULT_CORS_PARAMS, DEFAULT_SECRET_KEY
+from .statics import DEFAULT_OPENAPI_THEME, DEFAULT_CORS_PARAMS, DEFAULT_SECRET_KEY
 from .templates import Templates
 
 
@@ -34,7 +34,7 @@ class API:
     :param templates_dir: The directory to use for templates. Will be created for you if it doesn't already exist.
     :param auto_escape: If ``True``, HTML and XML templates will automatically be escaped.
     :param enable_hsts: If ``True``, send all responses to HTTPS URLs.
-    :param api_theme: OpenAPI documentation theme, must be one of ``elements``, ``rapidoc``, ``redoc``, ``swagger_ui``
+    :param openapi_theme: OpenAPI documentation theme, must be one of ``elements``, ``rapidoc``, ``redoc``, ``swagger_ui``
     """
 
     status_codes = status_codes
@@ -61,7 +61,7 @@ class API:
         cors=False,
         cors_params=DEFAULT_CORS_PARAMS,
         allowed_hosts=None,
-        api_theme=DEFAULT_API_THEME,
+        openapi_theme=DEFAULT_OPENAPI_THEME,
     ):
         self.background = BackgroundQueue()
 
@@ -128,7 +128,7 @@ class API:
                 license=license,
                 openapi_route=openapi_route,
                 static_route=static_route,
-                api_theme=api_theme,
+                openapi_theme=openapi_theme,
             )
 
         # TODO: Update docs for templates

--- a/responder/ext/schema/__init__.py
+++ b/responder/ext/schema/__init__.py
@@ -4,7 +4,7 @@ from apispec import APISpec, yaml_utils
 from apispec.ext.marshmallow import MarshmallowPlugin
 
 from responder import status_codes
-from responder.statics import OPENAPI_THEMES, DEFAULT_OPENAPI_THEME
+from responder.statics import DEFAULT_OPENAPI_THEME, OPENAPI_THEMES
 from responder.templates import Templates
 
 
@@ -37,7 +37,9 @@ class Schema:
         self.openapi_version = openapi
         self.openapi_route = openapi_route
 
-        self.docs_theme = openapi_theme if openapi_theme in OPENAPI_THEMES else DEFAULT_OPENAPI_THEME
+        self.docs_theme = (
+            openapi_theme if openapi_theme in OPENAPI_THEMES else DEFAULT_OPENAPI_THEME
+        )
         self.docs_route = docs_route
 
         self.plugins = [MarshmallowPlugin()] if plugins is None else plugins

--- a/responder/ext/schema/__init__.py
+++ b/responder/ext/schema/__init__.py
@@ -4,7 +4,7 @@ from apispec import APISpec, yaml_utils
 from apispec.ext.marshmallow import MarshmallowPlugin
 
 from responder import status_codes
-from responder.statics import API_THEMES, DEFAULT_API_THEME
+from responder.statics import OPENAPI_THEMES, DEFAULT_OPENAPI_THEME
 from responder.templates import Templates
 
 
@@ -23,7 +23,7 @@ class Schema:
         openapi_route="/schema.yml",
         docs_route="/docs/",
         static_route="/static",
-        api_theme=DEFAULT_API_THEME,
+        openapi_theme=DEFAULT_OPENAPI_THEME,
     ):
         self.app = app
         self.schemas = {}
@@ -37,7 +37,7 @@ class Schema:
         self.openapi_version = openapi
         self.openapi_route = openapi_route
 
-        self.docs_theme = api_theme if api_theme in API_THEMES else DEFAULT_API_THEME
+        self.docs_theme = openapi_theme if openapi_theme in OPENAPI_THEMES else DEFAULT_OPENAPI_THEME
         self.docs_route = docs_route
 
         self.plugins = [MarshmallowPlugin()] if plugins is None else plugins

--- a/responder/statics.py
+++ b/responder/statics.py
@@ -1,6 +1,6 @@
-API_THEMES = ["elements", "rapidoc", "redoc", "swagger_ui"]
+OPENAPI_THEMES = ["elements", "rapidoc", "redoc", "swagger_ui"]
 DEFAULT_ENCODING = "utf-8"
-DEFAULT_API_THEME = "swagger_ui"
+DEFAULT_OPENAPI_THEME = "swagger_ui"
 DEFAULT_SESSION_COOKIE = "Responder-Session"
 DEFAULT_SECRET_KEY = "NOTASECRET"
 


### PR DESCRIPTION
Update the variable throughout all relevant locations and conduct thorough testing to ensure seamless rendering of all OpenAPI documentation tools, including Swagger, Redoc, and Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed the theme parameter across various modules from `api_theme` to `openapi_theme` to better reflect its purpose.
  
- **Documentation**
  - Updated references from `API_THEMES` to `OPENAPI_THEMES` and from `DEFAULT_API_THEME` to `DEFAULT_OPENAPI_THEME` in documentation and configurations to align with the new naming convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->