### PR TITLE
CI: Slightly update GHA configuration, now targeting branch `main`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,13 +1,15 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
-name: tests
+name: "Tests"
 
 on:
   push:
-    branches: [ develop ]
-  pull_request:
-    branches: [ develop ]
+    branches: [ main ]
+  pull_request: ~
+  workflow_dispatch:
+
+# Cancel redundant in-progress jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -25,5 +27,3 @@ jobs:
     - uses: yezz123/setup-uv@v4
     - run: uv pip install -r requirements.txt --system
     - run: pytest
-
-      


### PR DESCRIPTION
## Problem
CI did not start on GH-526.

## Details
Also, add a configuration snippet to cancel redundant in-progress jobs, in order to save resources. That means running jobs are terminated when subsequently pushing to the same branch / updating the same PR, DWIM-like.