### PR TITLE
Docs: Update to `jinja2<3.2`, Dependabot admonitions versions <3.1.4

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 alabaster<0.8
-jinja2<2.11
+jinja2<3.2
 markupsafe<2
 readme-renderer<23
 sphinx>=5,<6


### PR DESCRIPTION
## About
What the title says.

## Details
It's only about building static docs, so there is no danger for this project. It's just a chore fix to properly dismiss the security warning signalled by Dependabot.

## References
- https://github.com/kennethreitz/responder/security/dependabot/61