### PR TITLE
Fix dispatching `static_route=None` on Windows

### DIFF
--- a/responder/api.py
+++ b/responder/api.py
@@ -65,7 +65,7 @@ class API:
 
         if static_dir is not None:
             if static_route is None:
-                static_route = static_dir
+                static_route = ""
             static_dir = Path(os.path.abspath(static_dir))
 
         self.static_dir = static_dir

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -1,6 +1,5 @@
 import random
 import string
-import sys
 from pathlib import Path
 
 import pytest
@@ -815,9 +814,9 @@ def test_allowed_hosts(enable_hsts, cors):
 
 def create_asset(static_dir: Path, name=None, parent_dir: str = None) -> Path:
     if name is None:
-        name = random.choices(string.ascii_letters, k=6)  # noqa: S311
+        name = "".join(random.choices(string.ascii_letters, k=6))  # noqa: S311
         # :3
-        ext = random.choices(string.ascii_letters, k=2)  # noqa: S311
+        ext = "".join(random.choices(string.ascii_letters, k=2))  # noqa: S311
         name = f"{name}.{ext}"
 
     if parent_dir is None:
@@ -833,8 +832,6 @@ def create_asset(static_dir: Path, name=None, parent_dir: str = None) -> Path:
 
 @pytest.mark.parametrize("static_route", [None, "/static", "/custom/static/route"])
 def test_staticfiles(tmp_path, static_route):
-    if sys.platform == "win32" and static_route is None:
-        raise pytest.skip("Route 'None' currently does not work on Windows")
     static_dir = tmp_path / "static"
     static_dir.mkdir()
 


### PR DESCRIPTION
## Problem
After improving CI/GHA to run software tests on Windows, there was a specific error exclusively tripping on that OS, when using `static_route=None`, i.e. when mounting a resource to the URL root.
- GH-545
- GH-548

## Solution
Fix a bit in the library, and another bit within its testing utilities, to harmonize path vs. URL computation.
