### PR TITLE
Dependencies: Remove `aiofiles`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ if sys.argv[-1] == "publish":
     sys.exit()
 
 required = [
-    "aiofiles",
     "apispec>=1.0.0b1",
     "chardet",
     "marshmallow",


### PR DESCRIPTION
Apparently, the package [aiofiles](https://pypi.org/project/aiofiles/) it is not used here.