### PR TITLE
Documentation: Migrate to Furo theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-alabaster<0.8
+furo
 jinja2<3.2
 markupsafe<4
 readme-renderer<45

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,5 @@ markupsafe<4
 readme-renderer<45
 sphinx>=5,<9
 sphinxcontrib-websupport<2.1
+sphinx-copybutton
+sphinxext.opengraph

--- a/docs/source/_templates/hacks.html
+++ b/docs/source/_templates/hacks.html
@@ -18,13 +18,13 @@
   }
 
   h1 {
-    font-family: "Mercury Text G1 A", "Mercury Text G1 B" !important;
+    /* font-family: "Mercury Text G1 A", "Mercury Text G1 B" !important; */
     font-style: normal !important;
     font-weight: 600 !important;
   }
 
   .section {
-    font-family: "Mercury Text G1 A", "Mercury Text G1 B" !important;
+    /* font-family: "Mercury Text G1 A", "Mercury Text G1 B" !important; */
     font-style: normal !important;
     font-weight: 400 !important;
   }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,6 +57,8 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
+    "sphinx_copybutton",
+    "sphinxext.opengraph",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -231,3 +233,37 @@ intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# Configure OpenGraph extension
+#
+# When making changes, check them using the RTD PR preview URL on https://www.opengraph.xyz/.
+#
+# About text lengths
+#
+# Original documentation says:
+# - ogp_description_length
+#   Configure the amount of characters taken from a page. The default of 200 is probably good
+#   for most people. If something other than a number is used, it defaults back to 200.
+#   -- https://sphinxext-opengraph.readthedocs.io/en/latest/#options
+#
+# Other people say:
+# - og:title 40 chars
+# - og:description has 2 max lengths:
+#   When the link is used in a Post, it's 300 chars. When a link is used in a Comment, it's 110 chars.
+#   So you can either treat it as 110, or, write your Descriptions to 300 but make sure the first 110
+#   is the critical part and still makes sense when it gets cut off.
+#   -- https://stackoverflow.com/questions/8914476/facebook-open-graph-meta-tags-maximum-content-length
+ogp_site_url = "https://responder.kennethreitz.org/"
+ogp_description_length = 300
+ogp_site_name = "Responder Documentation"
+ogp_image = "https://responder.kennethreitz.org/_static/responder.png"
+ogp_image_alt = False
+ogp_use_first_image = False
+ogp_type = "website"
+ogp_enable_meta_description = True
+
+# Configure Sphinx-copybutton
+copybutton_remove_prompts = True
+copybutton_line_continuation_character = "\\"
+copybutton_prompt_text = r">>> |\.\.\. |\$ |sh\$ |PS> |cr> |mysql> |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,29 +92,34 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "alabaster"
+html_theme = "furo"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
 html_theme_options = {
-    "show_powered_by": False,
-    "github_user": "kennethreitz",
-    "github_repo": "responder",
-    "github_banner": False,
-    "show_related": False,
+    # Configure VCS.
+    # https://pradyunsg.me/furo/customisation/top-of-page-buttons/#with-popular-vcs-hosts
+    "source_repository": "https://github.com/kennethreitz/responder/",
+    "source_branch": "main",
+    "source_directory": "docs/source/",
 }
 
 
 html_sidebars = {
-    "index": ["sidebarintro.html", "sourcelink.html", "searchbox.html", "hacks.html"],
+    "index": [
+        "sidebarintro.html",
+        #"sourcelink.html",
+        #"searchbox.html",
+        "hacks.html",
+    ],
     "**": [
         "sidebarlogo.html",
         "localtoc.html",
-        "relations.html",
-        "sourcelink.html",
-        "searchbox.html",
+        #"relations.html",
+        #"sourcelink.html",
+        #"searchbox.html",
         "hacks.html",
     ],
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -111,7 +111,7 @@ Use ``uv`` for fast installation.
 
     uv pip install --upgrade 'responder'
 
-Or use standard pip where ``uv`` is not available.
+Or use standard ``pip`` on systems where ``uv`` is not available.
 
 .. code-block:: shell
 
@@ -119,9 +119,11 @@ Or use standard pip where ``uv`` is not available.
 
 Responder supports **Python 3.6+**.
 
+Design
+------
 
-The Basic Idea
---------------
+Concepts
+........
 
 The primary concept here is to bring the niceties that are brought forth from both Flask and Falcon and unify them into a single framework, along with some new ideas I have. I also wanted to take some of the API primitives that are instilled in the Requests library and put them into a web framework. So, you'll find a lot of parallels here with Requests.
 
@@ -132,7 +134,7 @@ The primary concept here is to bring the niceties that are brought forth from bo
 - ``resp.status_code``, ``req.method``, ``req.url``, and other familiar friends.
 
 Ideas
------
+.....
 
 - Flask-style route expression, with new capabilities -- all while using Python 3.6+'s new f-string syntax.
 - I love Falcon's "every request and response is passed into each view and mutated" methodology, especially ``response.media``, and have used it here. In addition to supporting JSON, I have decided to support YAML as well, as Kubernetes is slowly taking over the world, and it uses YAML for all the things. Content-negotiation and all that.

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -68,8 +68,8 @@ Writing Tests
     ========================== 1 passed in 0.10 seconds ==========================
 
 
-(Optional) Proper Python Package
---------------------------------
+Proper Python Package
+---------------------
 
 Optionally, you can not rely on relative imports, and instead install your api as a proper package. This requires:
 


### PR DESCRIPTION
## About
I don't know if you are going to stick with the [Alabaster theme](https://alabaster.readthedocs.io/) forever, but looking at [WhiteNoise](https://whitenoise.readthedocs.io/) for example, but also many other projects, this patch is giving it a shot for [Responder](https://responder.kennethreitz.org/) as well to render its documentation using the [Furo theme](https://pradyunsg.me/furo/) for [Sphinx](https://www.sphinx-doc.org/).

## Status
This patch does not have any priority, needs additional work, and is just here to probe interests.

## Thoughts
What do you think about it, @kennethreitz?
