### PR TITLE
Documentation: Unlock writing in Markdown, using Sphinx/MyST. Add Sphinx extensions "copybutton" and "opengraph".

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ Requests.
 
 ## Development
 
-See [Development Sandbox](DEVELOP.md).
+See [Development Sandbox](https://responder.kennethreitz.org/sandbox.html).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,7 +57,10 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
+    "myst_parser",
     "sphinx_copybutton",
+    "sphinx_design",
+    "sphinx_design_elements",
     "sphinxext.opengraph",
 ]
 
@@ -229,7 +232,26 @@ intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
-# Configure OpenGraph extension
+# -- Options for MyST --------------------------------------------------------
+
+myst_heading_anchors = 3
+myst_enable_extensions = [
+    "attrs_block",
+    "attrs_inline",
+    "colon_fence",
+    "deflist",
+    "fieldlist",
+    "html_admonition",
+    "html_image",
+    "linkify",
+    "replacements",
+    "strikethrough",
+    "substitution",
+    "tasklist",
+]
+myst_substitutions = {}
+
+# -- Options for OpenGraph ---------------------------------------------------
 #
 # When making changes, check them using the RTD PR preview URL on https://www.opengraph.xyz/.
 #
@@ -257,7 +279,8 @@ ogp_use_first_image = False
 ogp_type = "website"
 ogp_enable_meta_description = True
 
-# Configure Sphinx-copybutton
+# -- Options for sphinx-copybutton -------------------------------------------
+
 copybutton_remove_prompts = True
 copybutton_line_continuation_character = "\\"
 copybutton_prompt_text = r">>> |\.\.\. |\$ |sh\$ |PS> |cr> |mysql> |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,6 +57,8 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
+    "sphinx_copybutton",
+    "sphinxext.opengraph",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -226,3 +228,37 @@ intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# Configure OpenGraph extension
+#
+# When making changes, check them using the RTD PR preview URL on https://www.opengraph.xyz/.
+#
+# About text lengths
+#
+# Original documentation says:
+# - ogp_description_length
+#   Configure the amount of characters taken from a page. The default of 200 is probably good
+#   for most people. If something other than a number is used, it defaults back to 200.
+#   -- https://sphinxext-opengraph.readthedocs.io/en/latest/#options
+#
+# Other people say:
+# - og:title 40 chars
+# - og:description has 2 max lengths:
+#   When the link is used in a Post, it's 300 chars. When a link is used in a Comment, it's 110 chars.
+#   So you can either treat it as 110, or, write your Descriptions to 300 but make sure the first 110
+#   is the critical part and still makes sense when it gets cut off.
+#   -- https://stackoverflow.com/questions/8914476/facebook-open-graph-meta-tags-maximum-content-length
+ogp_site_url = "https://responder.kennethreitz.org/"
+ogp_description_length = 300
+ogp_site_name = "Responder Documentation"
+ogp_image = "https://responder.kennethreitz.org/_static/responder.png"
+ogp_image_alt = False
+ogp_use_first_image = False
+ogp_type = "website"
+ogp_enable_meta_description = True
+
+# Configure Sphinx-copybutton
+copybutton_remove_prompts = True
+copybutton_line_continuation_character = "\\"
+copybutton_prompt_text = r">>> |\.\.\. |\$ |sh\$ |PS> |cr> |mysql> |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -117,7 +117,14 @@ Or use standard pip where ``uv`` is not available.
 
     pip install --upgrade 'responder'
 
-Responder supports **Python 3.6+**.
+Responder supports **Python 3.6+**. If you are looking at installing Responder
+for hacking on it, please refer to the :ref:`sandbox` documentation.
+
+.. toctree::
+   :hidden:
+
+   sandbox
+
 
 
 The Basic Idea

--- a/docs/source/sandbox.md
+++ b/docs/source/sandbox.md
@@ -1,16 +1,23 @@
+(sandbox)=
 # Development Sandbox
 
+## Setup
 Set up a development sandbox.
 
-Acquire sources and install project in editable mode.
+Acquire sources and create virtualenv.
 ```shell
 git clone https://github.com/kennethreitz/responder
 cd responder
 python3 -m venv .venv
 source .venv/bin/activate
-pip install --editable '.[graphql,develop,docs,release,test]'
 ```
 
+Install project in editable mode.
+```shell
+pip install --editable '.[full,develop,docs,release,test]'
+```
+
+## Operations
 Invoke linter and software tests.
 ```shell
 poe check

--- a/setup.py
+++ b/setup.py
@@ -124,6 +124,8 @@ setup(
         "docs": [
             "alabaster<1.1",
             "sphinx>=5,<9",
+            "sphinx-copybutton",
+            "sphinxext.opengraph",
         ],
         "graphql": ["graphene"],
         "release": ["build", "twine"],

--- a/setup.py
+++ b/setup.py
@@ -123,8 +123,10 @@ setup(
         ],
         "docs": [
             "alabaster<1.1",
+            "myst-parser[linkify]",
             "sphinx>=5,<9",
             "sphinx-copybutton",
+            "sphinx-design-elements",
             "sphinxext.opengraph",
         ],
         "graphql": ["graphene"],


### PR DESCRIPTION
## About
We would like to contribute more documentation, but would like to author it in Markdown format instead of reStructuredText, thus modernizing tech writing a bit, based on excellent work of others.

## What's Inside
- [Unlock writing in Markdown, using Sphinx/MyST](https://github.com/kennethreitz/responder/pull/559/commits/eee4d5f35fc89f08b3176dd09d311a692df53294)
- [Add Sphinx extensions "copybutton" and "opengraph"](https://github.com/kennethreitz/responder/pull/559/commits/40811292a17b62d778d7a91cf93f2eaca0ea5050)

## Preview
This page is now written in Markdown, stored in markdown.md.
https://responder-testdrive.readthedocs.io/en/latest/sandbox.html
That the preview is rendering means it also works well on RTD.

## References
- [Technical advancements in Sphinx](https://community.panodata.org/t/technical-advancements-in-sphinx/278)
- [MyST - Markedly Structured Text - Parser](https://myst-parser.readthedocs.io/)
- [sphinx{design}](https://sphinx-design.readthedocs.io/)
- [sphinx-design-elements](https://sphinx-design-elements.readthedocs.io/)
