### PR TITLE
Sandbox: Enable mypy type checker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,20 @@ markers = [
 ]
 xfail_strict = true
 
+[tool.mypy]
+packages = [
+  "responder",
+]
+exclude = [
+]
+check_untyped_defs = true
+explicit_package_bases = true
+ignore_missing_imports = true
+implicit_optional = true
+install_types = true
+namespace_packages = true
+non_interactive = true
+
 [tool.poe.tasks]
 
 check = [
@@ -98,7 +112,7 @@ lint = [
   { cmd = "ruff format --check ." },
   { cmd = "ruff check ." },
   { cmd = "validate-pyproject pyproject.toml" },
-  # { cmd = "mypy" },
+  { cmd = "mypy" },
 ]
 
 release = [

--- a/responder/api.py
+++ b/responder/api.py
@@ -221,11 +221,16 @@ class API:
             with open(index, "r") as f:
                 resp.html = f.read()
         else:
-            resp.status_code = status_codes.HTTP_404
+            resp.status_code = status_codes.HTTP_404  # type: ignore[attr-defined]
             resp.text = "Not found."
 
     def redirect(
-        self, resp, location, *, set_text=True, status_code=status_codes.HTTP_301
+        self,
+        resp,
+        location,
+        *,
+        set_text=True,
+        status_code=status_codes.HTTP_301,  # type: ignore[attr-defined]
     ):
         """
         Redirects a given response to a given location.
@@ -365,7 +370,7 @@ class API:
             port = 5042
 
         def spawn():
-            uvicorn.run(self, host=address, port=port, debug=debug, **options)
+            uvicorn.run(self, host=address, port=port, **options)
 
         spawn()
 

--- a/responder/ext/schema/__init__.py
+++ b/responder/ext/schema/__init__.py
@@ -133,6 +133,6 @@ class OpenAPISchema:
         resp.html = self.docs
 
     def schema_response(self, req, resp):
-        resp.status_code = status_codes.HTTP_200
+        resp.status_code = status_codes.HTTP_200  # type: ignore[attr-defined]
         resp.headers["Content-Type"] = "application/x-yaml"
         resp.content = self.openapi

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ setup(
         ],
         "graphql": ["graphene"],
         "release": ["build", "twine"],
-        "test": ["pytest", "pytest-cov", "pytest-mock", "flask"],
+        "test": ["flask", "mypy", "pytest", "pytest-cov", "pytest-mock"],
     },
     include_package_data=True,
     license="Apache 2.0",


### PR DESCRIPTION
## About
This patch enables mypy to be invoked on `poe check`, thus also slotting it into CI checks on GHA.

## Status
It will need more work after other feature patches have been merged. Hereby handing this in as a https://github.com/kennethreitz/responder/labels/question asking for feedback if you appreciate or discourage this improvement to the code base.
