### PR TITLE
Dependencies: Migrate from WhiteNoise to ServeStatic

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,7 +42,7 @@ Powered by `Starlette`_. That ``async`` declaration is optional.
 
 The little program demonstrates an `ASGI`_ application using `Responder`_,
 including production-ready components like the `uvicorn`_ webserver, based
-on `uvloop`_, the static files server `WhiteNoise`_, and the `Jinja`_
+on `uvloop`_, the static files server `ServeStatic`_, and the `Jinja`_
 templating library pre-installed.
 
 Features
@@ -165,10 +165,10 @@ Indices and tables
 .. _Django REST Framework: https://www.django-rest-framework.org/
 .. _f-string syntax: https://docs.python.org/3/whatsnew/3.6.html#pep-498-formatted-string-literals
 .. _Jinja: https://jinja.palletsprojects.com/en/stable/
+.. _ServeStatic: https://archmonger.github.io/ServeStatic/latest/
 .. _Slowloris: https://en.wikipedia.org/wiki/Slowloris_(computer_security)
 .. _Starlette: https://www.starlette.io/
 .. _Responder: https://responder.kennethreitz.org/
 .. _Two Scoops of Django: https://www.feldroy.com/two-scoops-press#two-scoops-of-django
 .. _uvicorn: https://www.uvicorn.org/
 .. _uvloop: https://uvloop.readthedocs.io/
-.. _WhiteNoise: https://whitenoise.readthedocs.io/en/latest/

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,12 @@ required = [
     "requests",
     "requests-toolbelt",
     "rfc3986",
+    # ServeStatic is the successor to WhiteNoise.
+    # WhiteNoise is used for backward compatibility with Python <3.8.
+    "servestatic; python_version>='3.8'",
     "starlette[full]",
     "uvicorn[standard]",
-    "whitenoise",
+    "whitenoise; python_version<'3.8'",
 ]
 
 


### PR DESCRIPTION
## About
@Archmonger told us about [ServeStatic](https://pypi.org/project/servestatic/), the designated successor of [WhiteNoise](https://pypi.org/project/whitenoise/). Thanks!

## References
@Archmonger shared:
> On a related note, `WhiteNoise` has received little maintenance for the last 5 years.
>
> It is suggested to consider switching to [`ServeStatic`](https://github.com/Archmonger/ServeStatic) instead.
>
> - https://github.com/kennethreitz/responder/pull/556#issuecomment-2440323987

## Backlog
- [ ] GH-563