### PR TITLE
Documentation: Update Read the Docs (RTD) configuration. Refactor Sphinx dependencies.

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
 
     - name: Install package and documentation dependencies
       run: |
-        uv pip install --system '.[develop]' --requirement=docs/requirements.txt
+        uv pip install --system '.[develop,docs]'
 
     - name: Run link checker
       run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,30 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+
+# Details
+# - https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+# Required
+version: 2
+
+build:
+  os: "ubuntu-24.04"
+  tools:
+    python: "3.12"
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+
+sphinx:
+  configuration: docs/source/conf.py
+
+  # Use standard HTML builder.
+  builder: html
+
+  # Fail on all warnings to avoid broken references.
+  fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF
+#formats:
+#  - pdf

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,10 @@ build:
 
 python:
   install:
-    - requirements: docs/requirements.txt
+      - method: pip
+        path: .
+        extra_requirements:
+          - docs
 
 sphinx:
   configuration: docs/source/conf.py

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -8,7 +8,7 @@ git clone https://github.com/kennethreitz/responder
 cd responder
 python3 -m venv .venv
 source .venv/bin/activate
-pip install --editable '.[graphql,develop,release,test]'
+pip install --editable '.[graphql,develop,docs,release,test]'
 ```
 
 Invoke linter and software tests.
@@ -19,4 +19,9 @@ poe check
 Format code.
 ```shell
 poe format
+```
+
+Documentation authoring.
+```shell
+poe docs-autobuild
 ```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,0 @@
-alabaster<1.1
-jinja2<3.2
-markupsafe<4
-readme-renderer<45
-sphinx>=5,<9
-sphinxcontrib-websupport<2.1

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,0 @@
-build:
-  image: latest
-
-python:
-  version: 3.6

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,10 @@ setup(
             "ruff; python_version>='3.7'",
             "validate-pyproject",
         ],
+        "docs": [
+            "alabaster<1.1",
+            "sphinx>=5,<9",
+        ],
         "graphql": ["graphene"],
         "release": ["build", "twine"],
         "test": ["pytest", "pytest-cov", "pytest-mock", "flask"],


### PR DESCRIPTION
## About
Update the configuration to make the project's documentation build on [Read the Docs](https://docs.readthedocs.io/). Also refactor the Sphinx dependencies to be hosted inline with the `setup.py` project metadata file. It all works technically well and provides much better tangibility in maintenance, without creating any redundancies.

## Preview
https://responder-testdrive.readthedocs.io/

## References
- GH-564