### PR TITLE
CLI 2025: Use `pueblo.sfa` for `responder run`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,8 @@ jobs:
         exclude:
 
           # Exclude test matrix slots that are no longer supported by GHA runners.
+          - os: 'ubuntu-20.04'
+            python-version: '3.6'
           - os: 'macos-latest'
             python-version: '3.6'
           - os: 'macos-latest'
@@ -88,14 +90,7 @@ jobs:
         cache-dependency-glob: |
           pyproject.toml
 
-    - name: Install and validate package (Python 3.6)
-      if: matrix.python-version == '3.6'
-      run: |
-        pip install '.[full,develop,test]'
-        poe test
-
-    - name: Install and validate package (Python >=3.6)
-      if: matrix.python-version != '3.6'
+    - name: Install and validate package
       run: |
         uv pip install '.[full,develop,test]'
         poe check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,22 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   argument, enabling usage on single-file applications. Beforehand, only
   invocations of Python modules were possible.
   ```shell
+  # Install Responder with CLI extension.
+  pip install 'responder[cli]'
+
   # Start Responder application defined in Python module.
   responder run acme.app:api
 
   # Start Responder application defined in a single Python file.
   responder run examples/helloworld.py:api
+  ```
+- CLI: `responder run` now also accepts URLs.
+  ```shell
+  # Install Responder with CLI extension (full).
+  pip install 'responder[cli-full]'
+
+  # Start Responder application defined in Python module at remote location.
+  responder run https://github.com/kennethreitz/responder/raw/refs/heads/main/examples/helloworld.py
   ```
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   the `<target>` argument of `responder run`, but is semantically different,
   as the former accepts a filesystem directory to the `package.json` file,
   but the latter expects a Python entrypoint specification.
+- Platform: Removed support for EOL Python 3.6
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Alternatively, install directly from the repository:
 
     pip install 'responder[full] @ git+https://github.com/kennethreitz/responder.git'
 
-Responder supports **Python 3.6+**.
+Responder supports **Python 3.7+**.
 
 # The Basic Idea
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -2,72 +2,149 @@ Responder CLI
 =============
 
 Responder installs a command line program ``responder``. Use it to launch
-a Responder application from a file or module.
+a Responder application from a file or module, either located on a local
+or remote filesystem, or object store.
 
-Launch application from file
-----------------------------
+Launch Module Entrypoint
+------------------------
 
-Acquire minimal example application, `helloworld.py`_,
-implementing a basic echo handler, and launch the HTTP service.
+For loading a Responder application from a Python module, you will refer to
+its ``API()`` instance using a `Python entry point object reference`_ that
+points to a Python object. It is either in the form ``importable.module``,
+or ``importable.module:object.attr``.
+
+A basic invocation command to launch a Responder application:
+
+.. code-block:: shell
+
+    responder run acme.app
+
+The command above assumes a Python package ``acme`` including an ``app``
+module ``acme/app.py`` that includes an attribute ``api`` that refers
+to a ``responder.API`` instance, reflecting the typical layout of
+a standard Responder application.
+
+Loading a Responder application using an entrypoint specification will
+inherit the capacities of `Python's import system`_, as implemented by
+`importlib`_.
+
+Launch Local File
+-----------------
+
+Acquire a minimal example single-file application, ``helloworld.py`` [1]_,
+to your local filesystem, giving you the chance to edit it, and launch the
+Responder HTTP service.
 
 .. code-block:: shell
 
     wget https://github.com/kennethreitz/responder/raw/refs/heads/main/examples/helloworld.py
     responder run helloworld.py
 
-In another terminal, invoke a HTTP request, for example using `HTTPie`_.
+.. note::
+
+    To validate the example application, invoke a HTTP request, for example using
+    `curl`_, `HTTPie`_, or your favourite browser at hand.
+
+    .. code-block:: shell
+
+        http http://127.0.0.1:5042/Hello
+
+    The response is no surprise.
+
+    ::
+
+        HTTP/1.1 200 OK
+        content-length: 13
+        content-type: text/plain
+        date: Sat, 26 Oct 2024 13:16:55 GMT
+        encoding: utf-8
+        server: uvicorn
+
+        Hello, world!
+
+.. [1] The Responder application `helloworld.py`_ implements a basic echo handler.
+
+Launch Remote File
+------------------
+
+You can also launch a single-file application where its Python file is stored
+on a remote location.
+
+Responder supports all filesystem adapters compatible with `fsspec`_, and
+installs the adapters for Azure Blob Storage (az), Google Cloud Storage (gs),
+GitHub, HTTP, and AWS S3 by default.
 
 .. code-block:: shell
 
-    http http://127.0.0.1:5042/hello
+    # Works 1:1.
+    responder run https://github.com/kennethreitz/responder/raw/refs/heads/main/examples/helloworld.py
+    responder run github://kennethreitz:responder@/examples/helloworld.py
 
-The response is no surprise.
-
-::
-
-    HTTP/1.1 200 OK
-    content-length: 13
-    content-type: text/plain
-    date: Sat, 26 Oct 2024 13:16:55 GMT
-    encoding: utf-8
-    server: uvicorn
-
-    hello, world!
-
-
-Launch application from module
-------------------------------
-
-If your Responder application has been implemented as a Python module,
-launch it like this:
+If you need access other kinds of remote targets, see the `list of
+fsspec-supported filesystems and protocols`_. The next section enumerates
+a few synthetic examples. The corresponding storage buckets do not even
+exist, so don't expect those commands to work.
 
 .. code-block:: shell
 
-    responder run acme.app
+    # Azure Blob Storage, Google Cloud Storage, and AWS S3.
+    responder run az://kennethreitz-assets/responder/examples/helloworld.py
+    responder run gs://kennethreitz-assets/responder/examples/helloworld.py
+    responder run s3://kennethreitz-assets/responder/examples/helloworld.py
 
-That assumes a Python package ``acme`` including an ``app`` module
-``acme/app.py`` that includes an attribute ``api`` that refers
-to a ``responder.API`` instance, reflecting the typical layout of
-a standard Responder application.
+    # Hadoop Distributed File System (hdfs), SSH File Transfer Protocol (sftp),
+    # Common Internet File System (smb), Web-based Distributed Authoring and
+    # Versioning (webdav).
+    responder run hdfs://kennethreitz-assets/responder/examples/helloworld.py
+    responder run sftp://user@host/kennethreitz/responder/examples/helloworld.py
+    responder run smb://workgroup;user:password@server:port/responder/examples/helloworld.py
+    responder run webdav+https://user:password@server:port/responder/examples/helloworld.py
 
-.. rubric:: Non-standard instance name
+.. tip::
 
-When your attribute that references the ``responder.API`` instance
-is called differently than ``api``, append it to the launch target
-address like this:
+    In order to install support for all filesystem types supported by fsspec, run:
+
+    .. code-block:: shell
+
+        uv pip install 'fsspec[full]'
+
+    When using ``uv``, this concludes within an acceptable time of approx.
+    25 seconds. If you need to be more selectively instead of using ``full``,
+    choose from one or multiple of the available `fsspec extras`_, which are:
+
+    abfs, arrow, dask, dropbox, fuse, gcs, git, github, hdfs, http, oci, s3,
+    sftp, smb, ssh.
+
+Launch with Non-Standard Instance Name
+--------------------------------------
+
+By default, Responder will acquire an ``responder.API`` instance using the
+symbol name ``api`` from the specified Python module.
+
+If your main application file uses a different name than ``api``, please
+append the designated symbol name to the launch target address.
+
+It works like this for module entrypoints and local files:
 
 .. code-block:: shell
 
     responder run acme.app:service
+    responder run /path/to/acme/app.py:service
 
-Within your ``app.py``, the instance would have been defined like this:
+It works like this for URLs:
+
+.. code-block:: shell
+
+    responder run http://app.server.local/path/to/acme/app.py#service
+
+Within your ``app.py``, the instance would have been defined to use
+the ``service`` symbol name instead of ``api``, like this:
 
 .. code-block:: python
 
     service = responder.API()
 
-
-Build JavaScript application
+Build JavaScript Application
 ----------------------------
 
 The ``build`` subcommand invokes ``npm run build``, optionally accepting
@@ -78,7 +155,7 @@ where it expects a regular NPM ``package.json`` file.
 
     responder build
 
-When specifying a target directory, responder will change to that
+When specifying a target directory, Responder will change to that
 directory beforehand.
 
 .. code-block:: shell
@@ -86,5 +163,12 @@ directory beforehand.
     responder build /path/to/project
 
 
+.. _curl: https://curl.se/
+.. _fsspec: https://filesystem-spec.readthedocs.io/en/latest/
+.. _fsspec extras: https://github.com/fsspec/filesystem_spec/blob/2024.12.0/pyproject.toml#L27-L69
 .. _helloworld.py: https://github.com/kennethreitz/responder/blob/main/examples/helloworld.py
 .. _HTTPie: https://httpie.io/docs/cli
+.. _importlib: https://docs.python.org/3/library/importlib.html
+.. _list of fsspec-supported filesystems and protocols: https://github.com/fsspec/universal_pathlib#currently-supported-filesystems-and-protocols
+.. _Python entry point object reference: https://packaging.python.org/en/latest/specifications/entry-points/
+.. _Python's import system: https://docs.python.org/3/reference/import.html

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -68,7 +68,11 @@ Launch Remote File
 ------------------
 
 You can also launch a single-file application where its Python file is stored
-on a remote location.
+on a remote location after installing the ``cli-full`` extra.
+
+.. code-block:: shell
+
+    uv pip install 'responder[cli-full]'
 
 Responder supports all filesystem adapters compatible with `fsspec`_, and
 installs the adapters for Azure Blob Storage (az), Google Cloud Storage (gs),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -221,6 +221,11 @@ linkcheck_ignore = [
     # Feldroy.com links are ignored because it blocks GHA.
     r"https://www.feldroy.com/.*",
 ]
+linkcheck_anchors_ignore_for_url = [
+    # Requires JavaScript.
+    # After opting-in to new GitHub issues, Sphinx can no longer grok the HTML anchor references.
+    r"https://github.com",
+]
 
 # -- Options for intersphinx extension ---------------------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -118,7 +118,7 @@ Or use standard pip where ``uv`` is not available.
 
     pip install --upgrade 'responder'
 
-Responder supports **Python 3.6+**. If you are looking at installing Responder
+Responder supports **Python 3.7+**. If you are looking at installing Responder
 for hacking on it, please refer to the :ref:`sandbox` documentation.
 
 .. toctree::

--- a/responder/api.py
+++ b/responder/api.py
@@ -4,20 +4,12 @@ from pathlib import Path
 import uvicorn
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.errors import ServerErrorMiddleware
+from starlette.middleware.exceptions import ExceptionMiddleware
 from starlette.middleware.gzip import GZipMiddleware
 from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.testclient import TestClient
-
-# Python 3.7+
-try:
-    from starlette.middleware.exceptions import ExceptionMiddleware
-# Python 3.6
-except ImportError:
-    from starlette.exceptions import (  # type: ignore[attr-defined,no-redef]
-        ExceptionMiddleware,
-    )
 
 from . import status_codes
 from .background import BackgroundQueue

--- a/responder/util/common.py
+++ b/responder/util/common.py
@@ -1,0 +1,9 @@
+from urllib.parse import urlparse
+
+
+def is_valid_url(url):
+    try:
+        result = urlparse(url)
+        return all([result.scheme, result.netloc])
+    except ValueError:
+        return False

--- a/responder/util/common.py
+++ b/responder/util/common.py
@@ -1,9 +1,0 @@
-from urllib.parse import urlparse
-
-
-def is_valid_url(url):
-    try:
-        result = urlparse(url)
-        return all([result.scheme, result.netloc])
-    except ValueError:
-        return False

--- a/responder/util/python.py
+++ b/responder/util/python.py
@@ -1,30 +1,15 @@
-import importlib
-import importlib.util
 import logging
-import sys
 import typing as t
-import uuid
-from pathlib import Path
-from tempfile import NamedTemporaryFile
-from types import ModuleType
 
-from upath import UPath
+from pueblo.sfa.core import InvalidTarget, SingleFileApplication
 
-from responder.util.common import is_valid_url
+__all__ = [
+    "InvalidTarget",
+    "SingleFileApplication",
+    "load_target",
+]
 
 logger = logging.getLogger(__name__)
-
-
-class InvalidTarget(Exception):
-    """
-    Raised when the target specification format is invalid.
-
-    This exception is raised when the target string does not conform to the expected
-    format of either a module path (e.g., 'acme.app:foo') or a file path
-    (e.g., '/path/to/acme/app.py').
-    """
-
-    pass
 
 
 def load_target(target: str, default_property: str = "api", method: str = "run") -> t.Any:
@@ -54,102 +39,6 @@ def load_target(target: str, default_property: str = "api", method: str = "run")
         >>> api.run()
     """  # noqa: E501
 
-    app_file = None
-    if is_valid_url(target):
-        upath = UPath(target)
-        frag = upath._url.fragment
-        suffix = upath.suffix
-        suffix = suffix.replace(f"#{frag}", "")
-        logger.info(f"Loading remote single-file application, source: {upath}")
-        name = "_".join([upath.parent.stem, upath.stem])
-        app_file = NamedTemporaryFile(prefix=f"{name}_", suffix=suffix, delete=False)
-        target = app_file.name
-        if frag:
-            target = f"{app_file.name}:{frag}"
-        logger.info(f"Writing remote single-file application, target: {target}")
-        app_file.write(upath.read_bytes())
-        app_file.flush()
-
-    # Sanity checks, as suggested by @coderabbitai. Thanks.
-    if not target or (":" in target and len(target.split(":")) != 2):
-        raise InvalidTarget(f"Invalid target format: {target}")
-
-    # Decode launch target location address.
-    # Module: acme.app:foo
-    # Path:   /path/to/acme/app.py:foo
-    target_fragments = target.split(":")
-    if len(target_fragments) > 1:
-        target = target_fragments[0]
-        prop = target_fragments[1]
-    else:
-        prop = default_property
-
-    # Validate property name follows Python identifier rules.
-    if not prop.isidentifier():
-        raise ValueError(f"Invalid property name: {prop}")
-
-    # Import launch target. Treat input location either as a filesystem path
-    # (/path/to/acme/app.py), or as a module address specification (acme.app).
-    path = Path(target)
-    if path.is_file():
-        app = load_file_module(path)
-    else:
-        app = importlib.import_module(target)
-
-    # Invoke launch target.
-    msg_prefix = f"Failed to import target '{target}'"
-    try:
-        api = getattr(app, prop, None)
-        if api is None:
-            raise AttributeError(f"Module has no API instance attribute '{prop}'")
-        if not hasattr(api, method):
-            raise AttributeError(f"API instance '{prop}' has no method '{method}'")
-        return api
-    except ImportError as ex:
-        raise ImportError(f"{msg_prefix}: {ex}") from ex
-    except AttributeError as ex:
-        raise AttributeError(f"{msg_prefix}: {ex}") from ex
-    except Exception as ex:
-        raise RuntimeError(f"{msg_prefix}: Unexpected error: {ex}") from ex
-
-
-def load_file_module(path: Path) -> ModuleType:
-    """
-    Load a Python file as a module using importlib.
-
-    Args:
-        path: Path to the Python file to load
-
-    Returns:
-        The loaded module object
-
-    Raises:
-        ImportError: If the module cannot be loaded
-    """
-
-    # Validate file extension
-    if path.suffix != ".py":
-        raise ValueError(f"File must have .py extension: {path}")
-
-    # Use unique surrogate module name.
-    unique_id = uuid.uuid4().hex
-    name = f"__{path.stem}_{unique_id}__"
-
-    spec = importlib.util.spec_from_file_location(name, path)
-    if spec is None or spec.loader is None:
-        raise ImportError(f"Failed loading module from file: {path}")
-    app = importlib.util.module_from_spec(spec)
-    sys.modules[name] = app
-    try:
-        spec.loader.exec_module(app)
-        return app
-    except (ImportError, SyntaxError) as ex:
-        sys.modules.pop(name, None)
-        raise ImportError(
-            f"Failed to execute module '{app}': {ex.__class__.__name__}: {ex}"
-        ) from ex
-    except Exception as ex:
-        sys.modules.pop(name, None)
-        raise RuntimeError(
-            f"Unexpected error executing module '{app}': {ex.__class__.__name__}: {ex}"
-        ) from ex
+    app = SingleFileApplication.from_spec(spec=target, default_property=default_property)
+    app.load()
+    return app.entrypoint

--- a/setup.py
+++ b/setup.py
@@ -121,8 +121,11 @@ setup(
     extras_require={
         "cli": [
             "docopt-ng",
-            "fsspec[abfs,gcs,github,http,libarchive,s3]",
-            "universal-pathlib",
+            "pueblo[sfa] @ git+https://github.com/pyveci/pueblo@sfa"
+        ],
+        "cli-full": [
+            "responder[cli]",
+            "pueblo[sfa-full] @ git+https://github.com/pyveci/pueblo@sfa"
         ],
         "develop": [
             "poethepoet",
@@ -138,7 +141,7 @@ setup(
             "sphinx-design-elements",
             "sphinxext.opengraph",
         ],
-        "full": ["responder[cli,graphql,openapi]"],
+        "full": ["responder[cli-full,graphql,openapi]"],
         "graphql": ["graphene<3", "graphql-server-core>=1.2,<2"],
         "openapi": ["apispec>=1.0.0"],
         "release": ["build", "twine"],

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     package_data={},
     entry_points={"console_scripts": ["responder=responder.ext.cli:cli"]},
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     setup_requires=[],
     install_requires=required,
     extras_require={
@@ -164,7 +164,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -121,11 +121,11 @@ setup(
     extras_require={
         "cli": [
             "docopt-ng",
-            "pueblo[sfa] @ git+https://github.com/pyveci/pueblo@sfa"
+            "pueblo[sfa]>=0.0.11",
         ],
         "cli-full": [
+            "pueblo[sfa-full]>=0.0.11",
             "responder[cli]",
-            "pueblo[sfa-full] @ git+https://github.com/pyveci/pueblo@sfa"
         ],
         "develop": [
             "poethepoet",

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,11 @@ setup(
     setup_requires=[],
     install_requires=required,
     extras_require={
-        "cli": ["docopt-ng"],
+        "cli": [
+            "docopt-ng",
+            "fsspec[abfs,gcs,github,http,libarchive,s3]",
+            "universal-pathlib",
+        ],
         "develop": [
             "poethepoet",
             "pyproject-fmt; python_version>='3.7'",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -150,20 +150,24 @@ def test_cli_build_invalid_package_json(
     assert any(item in stderr for item in to_list(expected_error))
 
 
+sfa_services_valid = [
+    str(Path("examples") / "helloworld.py"),
+    "https://github.com/kennethreitz/responder/raw/refs/heads/main/examples/helloworld.py",
+]
+
+
 # The test is marked as flaky due to potential race conditions in server startup
 # and port availability. Known error codes by platform:
 # - macOS:   [Errno 61] Connection refused (Failed to establish a new connection)
 # - Linux:   [Errno 111] Connection refused (Failed to establish a new connection)
 # - Windows: [WinError 10061] No connection could be made because target machine
 #            actively refused it
-@pytest.mark.flaky(reruns=5, reruns_delay=2)
-def test_cli_run(capfd):
+@pytest.mark.flaky(reruns=3, reruns_delay=2, only_rerun=["TimeoutError"])
+@pytest.mark.parametrize("target", sfa_services_valid, ids=sfa_services_valid)
+def test_cli_run(capfd, target):
     """
     Verify that `responder run` works as expected.
     """
-
-    # Invoke `responder run`.
-    target = Path("examples") / "helloworld.py"
 
     # Start a Responder service instance in the background, using its CLI.
     # Make it terminate itself after serving one HTTP request.


### PR DESCRIPTION
## About
_SFA – Single File Applications._

- **Pitch:** Use [PEP 723](https://peps.python.org/pep-0723/) for defining inline dependencies, like [marimo](https://pypi.org/project/marimo/) and others are doing it already.
  https://github.com/pyveci/pueblo/discussions/139

- **Refactoring:** Use code from [pueblo](https://pypi.org/project/pueblo/) to implement application launching.
  `pueblo.sfa` provides a few utility routines for discovering and invoking Python code.

- **Feature:** Unlock loading application from remote location, using `fsspec`.
