### PR TITLE
Run sync lifecycle and exception handlers off the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Synchronous lifecycle handlers (`startup`/`shutdown` events) and synchronous
+  exception handlers now run in a thread pool instead of directly on the event
+  loop, so a blocking call in one no longer stalls the server.
+
 ## [v7.1.3] - 2026-07-01
 
 ### Fixed

--- a/responder/api.py
+++ b/responder/api.py
@@ -867,7 +867,8 @@ class API:
             if is_async:
                 await func(req, resp, exc)
             else:
-                func(req, resp, exc)
+                # Keep a blocking handler off the event loop.
+                await run_in_threadpool(func, req, resp, exc)
             if resp.status_code is None:
                 resp.status_code = 500
             body, headers = await resp.body

--- a/responder/routes.py
+++ b/responder/routes.py
@@ -1582,7 +1582,8 @@ class Router:
             if inspect.iscoroutinefunction(handler):
                 await handler()
             else:
-                handler()
+                # Run blocking startup/shutdown handlers off the event loop.
+                await run_in_threadpool(handler)
 
     def add_dependency(
         self, name: str, provider: Callable, scope: str = "request"

--- a/tests/test_sync_handlers_offloop.py
+++ b/tests/test_sync_handlers_offloop.py
@@ -1,0 +1,65 @@
+"""Sync lifecycle and exception handlers must run off the event loop.
+
+A blocking sync handler executed directly on the loop stalls the whole
+server. Both paths now route through ``run_in_threadpool``. We detect this
+by calling ``asyncio.get_running_loop()`` inside the handler: it succeeds on
+the loop thread but raises ``RuntimeError`` inside a threadpool worker.
+"""
+
+import asyncio
+
+import responder
+
+
+def _ran_off_loop():
+    try:
+        asyncio.get_running_loop()
+        return False
+    except RuntimeError:
+        return True
+
+
+def test_sync_startup_handler_runs_off_event_loop():
+    api = responder.API(allowed_hosts=[";"], session_https_only=False)
+    seen = {}
+
+    @api.on_event("startup")
+    def startup():
+        seen["off_loop"] = _ran_off_loop()
+
+    with api.requests:
+        pass
+
+    assert seen["off_loop"] is True
+
+
+def test_sync_shutdown_handler_runs_off_event_loop():
+    api = responder.API(allowed_hosts=[";"], session_https_only=False)
+    seen = {}
+
+    @api.on_event("shutdown")
+    def shutdown():
+        seen["off_loop"] = _ran_off_loop()
+
+    with api.requests:
+        pass
+
+    assert seen["off_loop"] is True
+
+
+def test_sync_exception_handler_runs_off_event_loop():
+    api = responder.API(allowed_hosts=[";"], session_https_only=False)
+    seen = {}
+
+    @api.exception_handler(ValueError)
+    def handle(req, resp, exc):
+        seen["off_loop"] = _ran_off_loop()
+        resp.media = {"error": "handled"}
+
+    @api.route("/boom")
+    def boom(req, resp):
+        raise ValueError("nope")
+
+    r = api.requests.get("/boom")
+    assert seen["off_loop"] is True
+    assert r.json() == {"error": "handled"}


### PR DESCRIPTION
## Summary

Follow-up to #610 from the same audit. Two remaining spots invoked **synchronous** handlers directly on the event loop, so a blocking call in any of them stalled the whole server:

- Sync `startup`/`shutdown` event handlers — `Router.trigger_event` (`routes.py`)
- Sync exception handlers — `_wrap_exc_handler`'s adapter (`api.py`)

Both now route through `run_in_threadpool`, matching how the rest of the framework dispatches sync callables (views, hooks, auth, dependency providers).

## Tests

New `tests/test_sync_handlers_offloop.py` proves each path runs off the loop, using the fact that `asyncio.get_running_loop()` succeeds on the loop thread but raises `RuntimeError` inside a threadpool worker:

- sync startup handler runs off-loop
- sync shutdown handler runs off-loop
- sync exception handler runs off-loop (and still produces its response)

Full suite: 743 passed, 1 skipped (php not installed); ruff clean; mypy clean.

## Notes

Changelog entry added under `[Unreleased]` — no version bump in this PR; cut the release when you're ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)