### PR TITLE
Match Content-Type case-insensitively per RFC 7231

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Synchronous lifecycle handlers (`startup`/`shutdown` events) and synchronous
   exception handlers now run in a thread pool instead of directly on the event
   loop, so a blocking call in one no longer stalls the server.
+- Content-Type matching is now case-insensitive, per RFC 7231. Requests sent
+  with e.g. `Application/JSON` or `Multipart/Form-Data` are negotiated and
+  parsed correctly instead of falling through to the wrong parser. Affects
+  `Request.is_json`, `Request.media()` format auto-detection, and multipart
+  form parsing (including an uppercased `Boundary` parameter name).
 
 ## [v7.1.3] - 2026-07-01
 

--- a/responder/formats.py
+++ b/responder/formats.py
@@ -99,7 +99,8 @@ def _parse_multipart(content: bytes, content_type: str) -> list[_PartData]:
     boundary = None
     for segment in content_type.split(";"):
         segment = segment.strip()
-        if segment.startswith("boundary="):
+        # Parameter names are case-insensitive; the boundary value is not.
+        if segment.lower().startswith("boundary="):
             boundary = segment.split("=", 1)[1].strip('"')
             break
 
@@ -145,7 +146,8 @@ def _parse_multipart(content: bytes, content_type: str) -> list[_PartData]:
 async def format_form(r, encode=False):
     if encode:
         return None
-    if "multipart/form-data" in r.mimetype:
+    # Media types are case-insensitive (RFC 7231 §3.1.1.1).
+    if "multipart/form-data" in r.mimetype.lower():
         parts = _parse_multipart(await r.content, r.mimetype)
         queries = []
         for part in parts:

--- a/responder/models.py
+++ b/responder/models.py
@@ -233,7 +233,8 @@ class Request:
     @property
     def is_json(self) -> bool:
         """Returns ``True`` if the request content type is JSON."""
-        return "json" in self.mimetype
+        # Media types are case-insensitive (RFC 7231 §3.1.1.1).
+        return "json" in self.mimetype.lower()
 
     @property
     def last_event_id(self) -> str | None:
@@ -435,8 +436,10 @@ class Request:
         """
 
         if format is None:
-            format = "yaml" if "yaml" in self.mimetype else "json"  # noqa: A001
-            format = "form" if "form" in self.mimetype else format  # noqa: A001
+            # Media types are case-insensitive (RFC 7231 §3.1.1.1).
+            mimetype = self.mimetype.lower()
+            format = "yaml" if "yaml" in mimetype else "json"  # noqa: A001
+            format = "form" if "form" in mimetype else format  # noqa: A001
 
         formatter: Callable
         if isinstance(format, str):

--- a/tests/test_content_type_case.py
+++ b/tests/test_content_type_case.py
@@ -1,0 +1,79 @@
+"""Content-Type matching is case-insensitive (RFC 7231 §3.1.1.1).
+
+A client (or intermediary proxy) may send ``Application/JSON`` or
+``Multipart/Form-Data``; the framework must still negotiate and parse the body
+rather than silently falling through to the wrong parser.
+"""
+
+import json
+
+from starlette.testclient import TestClient
+
+import responder
+
+
+def _client(api):
+    return TestClient(api, base_url="http://;")
+
+
+def _api():
+    return responder.API(allowed_hosts=[";"], session_https_only=False)
+
+
+def test_uppercase_json_content_type_is_parsed():
+    api = _api()
+
+    @api.route("/echo", methods=["POST"])
+    async def echo(req, resp):
+        resp.media = {"got": await req.media(), "is_json": req.is_json}
+
+    r = _client(api).post(
+        "/echo",
+        content=json.dumps({"a": 1}),
+        headers={"Content-Type": "Application/JSON"},
+    )
+    assert r.status_code == 200
+    assert r.json() == {"got": {"a": 1}, "is_json": True}
+
+
+def test_uppercase_urlencoded_content_type_is_parsed():
+    api = _api()
+
+    @api.route("/form", methods=["POST"])
+    async def form(req, resp):
+        data = await req.media()
+        resp.media = {"name": data.get("name")}
+
+    r = _client(api).post(
+        "/form",
+        content="name=widget",
+        headers={"Content-Type": "Application/X-WWW-Form-Urlencoded"},
+    )
+    assert r.status_code == 200
+    assert r.json() == {"name": "widget"}
+
+
+def test_uppercase_multipart_content_type_is_parsed():
+    api = _api()
+
+    @api.route("/multipart", methods=["POST"])
+    async def multipart(req, resp):
+        data = await req.media("form")
+        resp.media = {"name": data.get("name")}
+
+    boundary = "MyBoundaryXYZ"  # mixed case must be preserved in the value
+    body = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="name"\r\n'
+        "\r\n"
+        "widget\r\n"
+        f"--{boundary}--\r\n"
+    ).encode()
+    r = _client(api).post(
+        "/multipart",
+        content=body,
+        # Both the type token and the ``Boundary`` parameter name are uppercased.
+        headers={"Content-Type": f"Multipart/Form-Data; Boundary={boundary}"},
+    )
+    assert r.status_code == 200
+    assert r.json() == {"name": "widget"}


### PR DESCRIPTION
## Summary

Content-negotiation polish from the audit backlog. Several Content-Type checks compared substrings against the **raw** header (`Request.mimetype` returns it verbatim), so a client or intermediary proxy sending `Application/JSON` or `Multipart/Form-Data` missed detection and fell through to the wrong parser — silently losing form/multipart data.

Media types, subtypes, and parameter names are case-insensitive (RFC 7231 §3.1.1.1). Normalized the comparisons at:

- `Request.is_json` (`models.py`)
- `Request.media()` format auto-detection — yaml/json/form (`models.py`)
- multipart detection and the `boundary=` parameter-name parse (`formats.py`)

The boundary **value** stays case-sensitive, as required.

## Scope note

I deliberately left the `Decimal` → `float` serialization alone. Changing it to emit strings (as the audit floated) is a documented, established behavior and would break consumers expecting a JSON number — not appropriate as a silent "polish" change.

## Tests

New `tests/test_content_type_case.py`: uppercase JSON (+`is_json`), uppercase urlencoded, and uppercase multipart with a mixed-case `Boundary` value.

Full suite: 743 passed, 1 skipped (php not installed); ruff clean; mypy clean. Changelog under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)