### PR TITLE
Tighten mypy config and fix the issues it surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- Tightened the mypy configuration: `no_implicit_optional`, `warn_unused_ignores`,
+  and `warn_redundant_casts` are now on. Removed the blanket
+  `implicit_optional = true`. Cleaned up the stale `# type: ignore` comments this
+  surfaced.
+
 ### Fixed
 
 - Synchronous lifecycle handlers (`startup`/`shutdown` events) and synchronous
@@ -17,6 +24,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   parsed correctly instead of falling through to the wrong parser. Affects
   `Request.is_json`, `Request.media()` format auto-detection, and multipart
   form parsing (including an uppercased `Boundary` parameter name).
+- `ResponderServer.__init__`'s `limit_max_requests` parameter was annotated
+  `int` but defaulted to `None`; it is now `int | None`.
 
 ## [v7.1.3] - 2026-07-01
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,10 +175,12 @@ exclude = []
 check_untyped_defs = true
 explicit_package_bases = true
 ignore_missing_imports = true
-implicit_optional = true
 install_types = true
 namespace_packages = true
+no_implicit_optional = true
 non_interactive = true
+warn_redundant_casts = true
+warn_unused_ignores = true
 
 [tool.pytest]
 ini_options.addopts = """

--- a/responder/ext/logging.py
+++ b/responder/ext/logging.py
@@ -100,10 +100,10 @@ class RequestContextFilter(logging.Filter):
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
-        record.request_id = _request_id.get()  # type: ignore[attr-defined]
-        record.request_method = _request_method.get()  # type: ignore[attr-defined]
-        record.request_path = _request_path.get()  # type: ignore[attr-defined]
-        record.client_ip = _client_ip.get()  # type: ignore[attr-defined]
+        record.request_id = _request_id.get()
+        record.request_method = _request_method.get()
+        record.request_path = _request_path.get()
+        record.client_ip = _client_ip.get()
         return True
 
 

--- a/responder/formats.py
+++ b/responder/formats.py
@@ -129,7 +129,7 @@ def _parse_multipart(content: bytes, content_type: str) -> list[_PartData]:
 
     parser = MultipartParser(
         boundary.encode(),
-        {  # type: ignore[arg-type]
+        {
             "on_part_begin": on_part_begin,
             "on_part_data": on_part_data,
             "on_header_field": on_header_field,

--- a/responder/params.py
+++ b/responder/params.py
@@ -24,7 +24,7 @@ try:
     from pydantic import TypeAdapter as _TypeAdapter
 except ImportError:  # pragma: no cover - pydantic is a core dep
     _TypeAdapter = None  # type: ignore[assignment,misc]
-    _Field = None  # type: ignore[assignment,misc]
+    _Field = None  # type: ignore[assignment]
 
 __all__ = ["Query", "Header", "Cookie", "Path", "Form", "File", "Depends"]
 

--- a/responder/util/cmd.py
+++ b/responder/util/cmd.py
@@ -101,7 +101,9 @@ class ResponderServer(threading.Thread):
         >>> server.stop()
     """
 
-    def __init__(self, target: str, port: int = 5042, limit_max_requests: int = None):
+    def __init__(
+        self, target: str, port: int = 5042, limit_max_requests: int | None = None
+    ):
         super().__init__()
         self._stopping = False
 

--- a/responder/util/python.py
+++ b/responder/util/python.py
@@ -7,7 +7,7 @@ from pathlib import Path
 try:
     from pueblo.sfa.core import InvalidTarget, SingleFileApplication
 except ImportError:
-    SingleFileApplication = None  # type: ignore[assignment, misc]
+    SingleFileApplication = None
 
     class InvalidTarget(Exception):  # type: ignore[no-redef]
         """Raised when an application target specification cannot be parsed."""


### PR DESCRIPTION
## Summary

From the audit backlog: the mypy config was permissive enough to hide real bugs. Tightened it to a right-sized increment and fixed everything that surfaced.

### Config changes (`pyproject.toml`)
- Dropped the blanket `implicit_optional = true`.
- Enabled `no_implicit_optional`, `warn_unused_ignores`, `warn_redundant_casts`.

### Fixes it surfaced
- **Real bug:** `ResponderServer.__init__`'s `limit_max_requests` was annotated `int` but defaulted to `None` → now `int | None` ([util/cmd.py](responder/util/cmd.py)).
- Removed 6 stale `# type: ignore` comments (in `util/python.py`, `ext/logging.py`, `formats.py`, and one code narrowed in `params.py`).

## Scope notes (what I deliberately did *not* do)

- **`disallow_incomplete_defs`** surfaces 53 partially-annotated functions across 13 files — a worthwhile but sizable cleanup that deserves its own focused PR, not a drive-by. Left off for now.
- **Narrowing `Handler`/`Dependency`/`Hook` in `types.py`** off `Callable[..., Any]`: I left these as-is. Handlers receive variadic kwargs (path params, injected deps, body models) so the parameter list must stay `...`, and their return is genuinely open (None / dict / str / bytes / model / `(body, status, headers)` tuple). Narrowing the return to a union would *reject* valid handler returns mypy currently accepts, breaking user annotations for no real safety gain. Bare `Any` is the correct public contract here.

## Verification

Full suite: 740 passed, 1 skipped (php not installed); ruff clean; mypy clean under the new config. Changelog under `[Unreleased]`.

Once this lands, CI (the `Lint & Types` job from #610) enforces the stricter config on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)