### PR TITLE
Add WebSocket idle timeout (API ws_idle_timeout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `API(ws_idle_timeout=...)` closes a WebSocket that waits too long for the next
+  inbound message (close code `1001`). The deadline resets on every message, so
+  it bounds idle time between messages, not total connection lifetime. Defaults
+  to `None` (unlimited), preserving existing behavior.
+
 ### Changed
 
 - Tightened the mypy configuration: `no_implicit_optional`, `warn_unused_ignores`,

--- a/responder/api.py
+++ b/responder/api.py
@@ -302,6 +302,7 @@ class API:
         auto_etag=False,
         auto_vary=True,
         request_timeout=None,
+        ws_idle_timeout=None,
         trace_dispatch=False,
         sessions="auto",
         session_backend=None,
@@ -350,6 +351,7 @@ class API:
         :param auto_etag: If ``True``, GET responses automatically get a content-hash ``ETag`` and matching ``If-None-Match`` requests receive ``304 Not Modified``.
         :param auto_vary: If ``True`` (the default since 6.0), content-negotiated responses get a ``Vary: Accept`` header (correct for shared caches). Pass ``False`` to opt out.
         :param request_timeout: Seconds a handler may run before the request is answered with ``504 Gateway Timeout``. ``None`` (the default) means unlimited.
+        :param ws_idle_timeout: Seconds a WebSocket may wait for the next inbound message before the server closes it (code ``1001``). The deadline resets on every message received, so it bounds *idle* time, not total connection lifetime. ``None`` (the default) means unlimited.
         :param trace_dispatch: If ``True``, emit debug logs for the documented route-dispatch order (before hooks, auth, dependencies, handler, after hooks).
         :param secret_key: Signing key for cookie sessions. Defaults to ``None``: with ``sessions="auto"`` a random per-process key is generated (with a warning); the old public ``"NOTASECRET"`` default is rejected. Set this (or the ``RESPONDER_SECRET_KEY`` env var) for stable, multi-worker sessions.
         :param sessions: ``"auto"`` (default) enables cookie sessions, auto-generating an ephemeral key if none is set; ``True`` requires a real ``secret_key`` (raises otherwise); ``False`` disables sessions entirely (``req.session`` then raises).
@@ -389,6 +391,7 @@ class API:
             auto_etag=auto_etag,
             auto_vary=auto_vary,
             request_timeout=request_timeout,
+            ws_idle_timeout=ws_idle_timeout,
             trace_dispatch=trace_dispatch,
             problem_details=problem_details,
         )

--- a/responder/routes.py
+++ b/responder/routes.py
@@ -1289,6 +1289,10 @@ class WebSocketRoute(BaseRoute):
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         ws = WebSocket(scope, receive, send)
 
+        idle_timeout = scope.get("ws_idle_timeout")
+        if idle_timeout is not None:
+            self._apply_idle_timeout(ws, idle_timeout)
+
         before_requests = scope.get("before_requests", {"http": [], "ws": []})
         route_before = getattr(self.endpoint, "_route_before", ())
         route_after = getattr(self.endpoint, "_route_after", ())
@@ -1345,9 +1349,27 @@ class WebSocketRoute(BaseRoute):
             await self._close_if_connected(ws, code=1008)
         except _MarkerValidationError:
             await self._close_if_connected(ws, code=1008)
+        except TimeoutError:
+            # No inbound message arrived within ws_idle_timeout; close the
+            # idle connection with 1001 (going away) instead of hanging.
+            await self._close_if_connected(ws, code=1001)
         finally:
             if resolver is not None:
                 await resolver.teardown()
+
+    @staticmethod
+    def _apply_idle_timeout(ws: WebSocket, timeout: float) -> None:
+        """Shadow ``ws.receive`` so each awaited receive must resolve within
+        ``timeout`` seconds. The deadline resets on every message, so it bounds
+        idle time between messages, not the total connection lifetime. On expiry
+        ``asyncio.wait_for`` raises ``TimeoutError``, handled in ``__call__``.
+        """
+        original_receive = ws.receive
+
+        async def receive_with_timeout() -> Any:
+            return await asyncio.wait_for(original_receive(), timeout)
+
+        ws.receive = receive_with_timeout  # type: ignore[method-assign]
 
     async def _run_before_hooks(self, hooks, ws: WebSocket) -> bool:
         for hook in hooks:
@@ -1470,6 +1492,7 @@ class Router:
         auto_etag: bool = False,
         auto_vary: bool = False,
         request_timeout: float | None = None,
+        ws_idle_timeout: float | None = None,
         trace_dispatch: bool = False,
         problem_details: bool = True,
     ) -> None:
@@ -1495,6 +1518,7 @@ class Router:
         self.auto_etag = auto_etag
         self.auto_vary = auto_vary
         self.request_timeout = request_timeout
+        self.ws_idle_timeout = ws_idle_timeout
         self.trace_dispatch = trace_dispatch
         self.problem_details = problem_details
         self._route_cache: dict[tuple[str, str], tuple[BaseRoute, dict]] = {}
@@ -1733,6 +1757,7 @@ class Router:
         scope["auto_etag"] = self.auto_etag
         scope["auto_vary"] = self.auto_vary
         scope["request_timeout"] = self.request_timeout
+        scope["ws_idle_timeout"] = self.ws_idle_timeout
         scope["trace_dispatch"] = self.trace_dispatch
         scope["problem_details"] = self.problem_details
 

--- a/tests/test_ws_idle_timeout.py
+++ b/tests/test_ws_idle_timeout.py
@@ -1,0 +1,74 @@
+"""WebSocket idle timeout: close a connection that goes quiet too long.
+
+The deadline resets on every inbound message, so it bounds idle time between
+messages rather than the total connection lifetime.
+"""
+
+import time
+
+import pytest
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+import responder
+
+
+def _client(api):
+    return TestClient(api, base_url="http://;")
+
+
+def test_idle_websocket_is_closed_with_1001():
+    api = responder.API(
+        allowed_hosts=[";"], session_https_only=False, ws_idle_timeout=0.2
+    )
+
+    @api.route("/ws", websocket=True)
+    async def ws_handler(ws):
+        await ws.accept()
+        # Block waiting for a client message that never arrives.
+        await ws.receive_text()
+
+    with _client(api).websocket_connect("ws://;/ws") as ws:
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            ws.receive_text()
+    assert excinfo.value.code == 1001
+
+
+def test_active_websocket_survives_beyond_the_idle_window():
+    # The deadline is per-message: a client that keeps talking, with no single
+    # gap exceeding the timeout, stays connected even though the total lifetime
+    # (0.6s of gaps) exceeds the 0.5s idle timeout.
+    api = responder.API(
+        allowed_hosts=[";"], session_https_only=False, ws_idle_timeout=0.5
+    )
+
+    @api.route("/ws", websocket=True)
+    async def echo(ws):
+        await ws.accept()
+        try:
+            while True:
+                msg = await ws.receive_text()
+                await ws.send_text(msg)
+        except WebSocketDisconnect:
+            pass
+
+    with _client(api).websocket_connect("ws://;/ws") as ws:
+        for i in range(3):
+            time.sleep(0.2)  # < timeout, so the connection must stay open
+            ws.send_text(f"ping-{i}")
+            assert ws.receive_text() == f"ping-{i}"
+
+
+def test_no_timeout_by_default():
+    # Without ws_idle_timeout, receive is not wrapped and behaves normally.
+    api = responder.API(allowed_hosts=[";"], session_https_only=False)
+
+    @api.route("/ws", websocket=True)
+    async def echo(ws):
+        await ws.accept()
+        msg = await ws.receive_text()
+        await ws.send_text(msg)
+
+    with _client(api).websocket_connect("ws://;/ws") as ws:
+        ws.send_text("hi")
+        assert ws.receive_text() == "hi"


### PR DESCRIPTION
## Summary

Last item from the audit backlog. WebSocket handlers had no way to bound how long they wait for the next client message, so a stuck or vanished peer (one that never sends a proper close frame) could hold a connection open forever. HTTP routes already have `request_timeout`; this brings parity to WebSockets.

## What it does

`API(ws_idle_timeout=<seconds>)` — plumbed through `Router` into the ASGI scope, mirroring `request_timeout`. `WebSocketRoute` shadows `ws.receive` so each awaited receive must resolve within the window:

- The deadline **resets on every inbound message**, so it bounds *idle* time between messages, not the total connection lifetime — a continuously active client is never killed.
- On expiry, `asyncio.wait_for` raises `TimeoutError`, caught in `__call__`, and the connection is closed with **1001 (going away)**.
- Defaults to `None` (unlimited) — existing behavior is unchanged, and `receive` isn't wrapped at all when unset.

## Tests

New `tests/test_ws_idle_timeout.py`:
- idle connection is closed with code 1001
- an active client (three 0.2s-spaced messages, total 0.6s > the 0.5s timeout, no single gap over it) stays connected — proving the per-message reset
- no wrapping / normal behavior when `ws_idle_timeout` is unset

Full suite: 749 passed, 1 skipped (php not installed); ruff clean; mypy clean under the tightened config from #613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)