### PR TITLE
Complete type annotations and enable mypy disallow_incomplete_defs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   and `warn_redundant_casts` are now on. Removed the blanket
   `implicit_optional = true`. Cleaned up the stale `# type: ignore` comments this
   surfaced.
+- Completed type annotations across the codebase and enabled mypy
+  `disallow_incomplete_defs`, so partially-annotated functions now fail type
+  checking. Annotations only — no runtime behavior changed.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ packages = [
 ]
 exclude = []
 check_untyped_defs = true
+disallow_incomplete_defs = true
 explicit_package_bases = true
 ignore_missing_imports = true
 install_types = true

--- a/responder/api.py
+++ b/responder/api.py
@@ -129,7 +129,7 @@ def _as_tuple(value):
     return (value,)
 
 
-def _auth_security_requirement(auth):
+def _auth_security_requirement(auth: Any) -> str | None:
     if hasattr(auth, "security_requirement"):
         return auth.security_requirement()
     if hasattr(auth, "scheme_name"):
@@ -137,7 +137,7 @@ def _auth_security_requirement(auth):
     return None
 
 
-def _auth_has_security_scheme(auth) -> bool:
+def _auth_has_security_scheme(auth: Any) -> bool:
     if not hasattr(auth, "security_scheme"):
         return False
     return auth.security_scheme() is not None
@@ -1041,7 +1041,7 @@ class API:
             allow_external=allow_external,
         )
 
-    def on_event(self, event_type: str, **args):
+    def on_event(self, event_type: str, **args: Any) -> Callable[..., Any]:
         """Decorator for registering functions or coroutines to run at certain events
         Supported events: startup, shutdown
 

--- a/responder/errors.py
+++ b/responder/errors.py
@@ -89,8 +89,8 @@ def problem_payload_for(
     *,
     title: str | None = None,
     errors: list[dict] | None = None,
-    request=None,
-    exc=None,
+    request: Any = None,
+    exc: Any = None,
 ) -> dict[str, Any]:
     """Build a problem-details payload with API-level enrichment applied."""
     payload = problem_payload(status_code, detail, title=title, errors=errors)
@@ -131,8 +131,8 @@ def problem_bytes_for(
     *,
     title: str | None = None,
     errors: list[dict] | None = None,
-    request=None,
-    exc=None,
+    request: Any = None,
+    exc: Any = None,
 ) -> bytes:
     return json.dumps(
         problem_payload_for(

--- a/responder/ext/auth.py
+++ b/responder/ext/auth.py
@@ -77,7 +77,7 @@ def _default_scopes(principal: Any) -> frozenset[str]:
     return frozenset()
 
 
-def _as_tuple(value) -> tuple:
+def _as_tuple(value: Any) -> tuple:
     if value is None:
         return ()
     if isinstance(value, str):
@@ -87,7 +87,7 @@ def _as_tuple(value) -> tuple:
     return (value,)
 
 
-def _scope_set(value) -> frozenset[str]:
+def _scope_set(value: Any) -> frozenset[str]:
     if value is None:
         return frozenset()
     if isinstance(value, str):
@@ -155,7 +155,12 @@ class AuthBase:
         api.add_security_scheme(self.scheme_name, self.security_scheme())
         return self
 
-    def requires(self, *scopes: str, roles=(), extractor=None) -> ScopedAuth:
+    def requires(
+        self,
+        *scopes: str,
+        roles: Any = (),
+        extractor: Callable | None = None,
+    ) -> ScopedAuth:
         """Wrap this scheme to also require ``scopes`` on the principal.
 
         The returned :class:`ScopedAuth` authenticates exactly like ``self`` and
@@ -183,7 +188,7 @@ class AuthBase:
     def _extract(self, req):
         raise NotImplementedError
 
-    def _has_credential(self, req) -> bool:
+    def _has_credential(self, req: Any) -> bool:
         return self._extract(req) is not None
 
     async def _verify(self, credential):
@@ -253,7 +258,12 @@ class AuthPolicy:
             api.add_security_scheme(self.scheme_name, scheme)
         return self
 
-    def requires(self, *scopes: str, roles=(), extractor=None) -> AuthPolicy:
+    def requires(
+        self,
+        *scopes: str,
+        roles: Any = (),
+        extractor: Callable | None = None,
+    ) -> AuthPolicy:
         if not hasattr(self._auth, "requires"):
             raise TypeError(
                 f"Auth policy {self.name!r} does not support scoped requirements"
@@ -308,7 +318,7 @@ class BearerAuth(AuthBase):
             return None
         return token.strip()
 
-    def _has_credential(self, req) -> bool:
+    def _has_credential(self, req: Any) -> bool:
         return bool(req.headers.get("Authorization"))
 
     async def _verify(self, token):
@@ -360,7 +370,7 @@ class BasicAuth(AuthBase):
             return None
         return (username, password)
 
-    def _has_credential(self, req) -> bool:
+    def _has_credential(self, req: Any) -> bool:
         return bool(req.headers.get("Authorization"))
 
     async def _verify(self, credential):
@@ -442,7 +452,14 @@ class ScopedAuth:
     surface as the operation's security-requirement value.
     """
 
-    def __init__(self, auth: AuthBase, scopes=(), *, roles=(), extractor=None):
+    def __init__(
+        self,
+        auth: AuthBase,
+        scopes: Any = (),
+        *,
+        roles: Any = (),
+        extractor: Callable | None = None,
+    ) -> None:
         self._auth = auth
         self.required_scopes = tuple(
             dict.fromkeys((*_as_tuple(scopes), *_as_tuple(roles)))
@@ -467,7 +484,12 @@ class ScopedAuth:
         self._auth.register(api)
         return self
 
-    def requires(self, *scopes: str, roles=(), extractor=None) -> ScopedAuth:
+    def requires(
+        self,
+        *scopes: str,
+        roles: Any = (),
+        extractor: Callable | None = None,
+    ) -> ScopedAuth:
         """Add further required scopes, returning a new wrapper (chainable)."""
         return ScopedAuth(
             self._auth,
@@ -546,7 +568,12 @@ class OptionalAuth:
         self._auth.register(api)
         return self
 
-    def requires(self, *scopes: str, roles=(), extractor=None) -> OptionalAuth:
+    def requires(
+        self,
+        *scopes: str,
+        roles: Any = (),
+        extractor: Callable | None = None,
+    ) -> OptionalAuth:
         return OptionalAuth(
             self._auth.requires(*scopes, roles=roles, extractor=extractor)
         )

--- a/responder/ext/clientgen.py
+++ b/responder/ext/clientgen.py
@@ -23,7 +23,7 @@ _METHODS = {"get", "post", "put", "patch", "delete", "options", "head"}
 _LANGUAGES = {"python", "javascript", "typescript", "ruby", "php"}
 
 
-def _load_spec(source) -> dict[str, Any]:
+def _load_spec(source: Any) -> dict[str, Any]:
     """Load an OpenAPI spec from an app, OpenAPISchema, dict, or YAML string."""
     if isinstance(source, dict):
         return source
@@ -1142,7 +1142,7 @@ class {class_name}
 
 
 def generate_client(
-    source, *, class_name: str = "APIClient", language: str = "python"
+    source: Any, *, class_name: str = "APIClient", language: str = "python"
 ) -> str:
     """Return source for a client generated from ``source``.
 
@@ -1427,7 +1427,11 @@ class {class_name}:
 
 
 def write_client(
-    source, path, *, class_name: str = "APIClient", language: str = "python"
+    source: Any,
+    path: str | Path,
+    *,
+    class_name: str = "APIClient",
+    language: str = "python",
 ) -> Path:
     """Generate a client and write it to ``path``."""
     target = Path(path)

--- a/responder/ext/logging.py
+++ b/responder/ext/logging.py
@@ -25,6 +25,7 @@ import logging
 import time
 import uuid
 from contextvars import ContextVar
+from typing import Any
 
 from starlette.datastructures import MutableHeaders
 
@@ -162,10 +163,10 @@ class LoggingMiddleware:
 
     def __init__(
         self,
-        app,
+        app: Any,
         logger_name: str = "responder.access",
         trust_proxy_headers: bool = False,
-    ):
+    ) -> None:
         self.app = app
         self.logger = get_logger(logger_name)
         self.trust_proxy_headers = trust_proxy_headers

--- a/responder/ext/openapi/__init__.py
+++ b/responder/ext/openapi/__init__.py
@@ -84,7 +84,7 @@ def _legacy_error_response(description: str, *, validation: bool = False) -> dic
     }
 
 
-def _json_schema_from_adapter(adapter) -> dict:
+def _json_schema_from_adapter(adapter: Any) -> dict:
     """Best-effort JSON Schema from a Pydantic adapter."""
     if adapter is None:
         return {"type": "string"}
@@ -96,7 +96,7 @@ def _json_schema_from_adapter(adapter) -> dict:
         return {"type": "string"}
 
 
-def _json_schema_from_annotation(annotation) -> dict | None:
+def _json_schema_from_annotation(annotation: Any) -> dict | None:
     """Best-effort JSON Schema for a plain annotation."""
     try:
         from pydantic import TypeAdapter
@@ -110,7 +110,7 @@ def _json_schema_from_annotation(annotation) -> dict | None:
         return None
 
 
-def _path_parameters(route, endpoint) -> list[dict]:
+def _path_parameters(route: Any, endpoint: Any) -> list[dict]:
     """OpenAPI ``parameters`` entries for a route's path parameters."""
     convertor_names = getattr(route, "param_convertor_names", {}) or {}
     parameters = {
@@ -155,7 +155,7 @@ def _path_parameters(route, endpoint) -> list[dict]:
     return list(parameters.values())
 
 
-def _query_parameters(endpoint) -> list[dict]:
+def _query_parameters(endpoint: Any) -> list[dict]:
     """OpenAPI ``parameters`` entries from a route's ``params_model``."""
     params_model = getattr(endpoint, "_params_model", None)
     if params_model is None:
@@ -211,7 +211,7 @@ def _marker_specs(endpoint):
         return ()
 
 
-def _marker_parameters(endpoint) -> list[dict]:
+def _marker_parameters(endpoint: Any) -> list[dict]:
     """OpenAPI parameters from Query()/Header()/Cookie() markers."""
     location_map = {"query": "query", "header": "header", "cookie": "cookie"}
     parameters = []
@@ -356,7 +356,7 @@ def _first_path_tag(path: str) -> str | None:
     return None
 
 
-def _default_operation_id(method: str, path: str, used) -> str:
+def _default_operation_id(method: str, path: str, used: set[str]) -> str:
     pieces = [method, *(p for p in re.split(r"[/{}:.-]+", path) if p)]
     base = _identifier("_".join(pieces).lower(), fallback=f"{method}_operation")
     name = base
@@ -388,7 +388,7 @@ def _apply_problem_responses(
         op["responses"].setdefault("504", response("Gateway Timeout"))
 
 
-def _doc_methods(route, has_body=False) -> list[str]:
+def _doc_methods(route: Any, has_body: bool = False) -> list[str]:
     """Lowercased HTTP methods to document for a route (no HEAD/OPTIONS)."""
     methods = getattr(route, "methods", None)
     if methods:
@@ -405,7 +405,7 @@ def _doc_methods(route, has_body=False) -> list[str]:
     return ["post"] if has_body else ["get"]
 
 
-def _has_param_validation(endpoint) -> bool:
+def _has_param_validation(endpoint: Any) -> bool:
     """Whether the route validates query/marker params (applies to any method)."""
     return bool(getattr(endpoint, "_params_model", None) or _marker_specs(endpoint))
 
@@ -509,7 +509,7 @@ def _openapi_schema_for(tp, downconvert):
     return schema, defs
 
 
-def _normalize_security(security) -> list[dict]:
+def _normalize_security(security: Any) -> list[dict]:
     """Normalize a route's ``security`` into OpenAPI requirement objects.
 
     Accepts a bare scheme name, a list of names, or a list of requirement dicts

--- a/responder/ext/pagination.py
+++ b/responder/ext/pagination.py
@@ -17,7 +17,8 @@ have already sliced the page yourself (e.g. with a ``LIMIT/OFFSET`` query).
 
 from __future__ import annotations
 
-from typing import Generic, TypeVar
+from collections.abc import Iterable
+from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel
 
@@ -40,7 +41,9 @@ class Page(BaseModel, Generic[T]):
     pages: int
 
 
-def paginate(items, *, page: int = 1, size: int = 20, total: int | None = None) -> Page:
+def paginate(
+    items: Iterable[Any], *, page: int = 1, size: int = 20, total: int | None = None
+) -> Page:
     """Wrap ``items`` in a :class:`Page`.
 
     :param items: The results. If ``total`` is ``None`` this is treated as the

--- a/responder/ext/query.py
+++ b/responder/ext/query.py
@@ -35,17 +35,19 @@ def _value(item, field):
     return getattr(item, field, None)
 
 
-def _sort_key(field) -> Callable[[Any], tuple[bool, Any]]:
+def _sort_key(field: str) -> Callable[[Any], tuple[bool, Any]]:
     """A sort key for ``field`` that puts ``None`` values last."""
 
-    def key(item) -> tuple[bool, Any]:
+    def key(item: Any) -> tuple[bool, Any]:
         value = _value(item, field)
         return (value is None, value)
 
     return key
 
 
-def parse_sort(spec, *, allowed=None) -> list[tuple[str, bool]]:
+def parse_sort(
+    spec: str | None, *, allowed: Any = None
+) -> list[tuple[str, bool]]:
     """Parse a sort spec into ``[(field, descending), ...]``.
 
     ``spec`` is a comma-separated list of fields; a leading ``-`` means
@@ -69,7 +71,7 @@ def parse_sort(spec, *, allowed=None) -> list[tuple[str, bool]]:
     return order
 
 
-def sort_items(items, spec, *, allowed=None) -> list:
+def sort_items(items: Any, spec: str | None, *, allowed: Any = None) -> list:
     """Return a new list sorted by a sort spec (see :func:`parse_sort`).
 
     ``None`` values sort last. A field whose values aren't mutually comparable
@@ -88,7 +90,7 @@ def sort_items(items, spec, *, allowed=None) -> list:
     return result
 
 
-def filter_items(items, filters) -> list:
+def filter_items(items: Any, filters: dict) -> list:
     """Filter ``items`` by equality against a ``{field: value}`` mapping.
 
     Entries whose value is ``None`` are skipped, so you can pass optional

--- a/responder/models.py
+++ b/responder/models.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from email.utils import format_datetime, parsedate_to_datetime
 from http.cookies import SimpleCookie
+from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 __all__ = ["Request", "Response", "QueryDict", "UploadFile"]
@@ -424,11 +425,11 @@ class Request:
         """``True`` if the request was made over HTTPS."""
         return self.url.scheme == "https"
 
-    def accepts(self, content_type) -> bool:
+    def accepts(self, content_type: str) -> bool:
         """Returns ``True`` if the incoming Request accepts the given ``content_type``."""
         return content_type in self.headers.get("Accept", [])
 
-    async def media(self, format: str | Callable | None = None):  # noqa: A002
+    async def media(self, format: str | Callable | None = None) -> Any:  # noqa: A002
         """Renders incoming json/yaml/form data as Python objects. Must be awaited.
 
         :param format: The name of the format being used.
@@ -456,7 +457,7 @@ class Request:
 
         return await formatter(self)
 
-    def media_sync(self, format: str | Callable | None = None):  # noqa: A002
+    def media_sync(self, format: str | Callable | None = None) -> Any:  # noqa: A002
         """Synchronous :meth:`media`, for use from **sync** handlers.
 
         Responder runs sync handlers in a worker thread, so this safely bridges
@@ -639,7 +640,7 @@ def _sse_frame(data=None, *, event=None, id=None, retry=None):  # noqa: A002
     return "\n".join(lines).encode("utf-8")
 
 
-def _format_sse_event(event) -> bytes:
+def _format_sse_event(event: Any) -> bytes:
     """Turn a yielded SSE event (str / bytes / dict) into wire bytes."""
     if isinstance(event, (bytes, bytearray)):
         return bytes(event)

--- a/responder/params.py
+++ b/responder/params.py
@@ -152,7 +152,7 @@ def Depends(provider):  # noqa: N802 - marker factory, FastAPI-style
     return _Depends(provider)
 
 
-def _is_sequence(annotation) -> bool:
+def _is_sequence(annotation: Any) -> bool:
     return annotation in (list, tuple, set, frozenset) or get_origin(annotation) in (
         list,
         tuple,
@@ -193,7 +193,7 @@ def _annotated_marker(annotation):
 _PARAM_CACHE: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
 
-def marker_params(handler, hints) -> tuple[ParamSpec, ...]:
+def marker_params(handler: Any, hints: dict) -> tuple[ParamSpec, ...]:
     """The marker-driven ``ParamSpec``s for ``handler`` (cached per function)."""
     import inspect
 
@@ -266,7 +266,7 @@ def marker_params(handler, hints) -> tuple[ParamSpec, ...]:
     return result
 
 
-def raw_value(spec: ParamSpec, request, path_params):
+def raw_value(spec: ParamSpec, request: Any, path_params: dict) -> Any:
     """Pull the raw (pre-validation) value for ``spec`` from the request.
 
     Returns ``...`` (Ellipsis) when the value is absent.

--- a/responder/routes.py
+++ b/responder/routes.py
@@ -8,7 +8,7 @@ import re
 import traceback
 import weakref
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import Any, Union
 
 __all__ = [
@@ -379,7 +379,9 @@ def _form_value(form, spec):
     return value if isinstance(value, str) else ...
 
 
-async def _resolve_markers(view, request, path_params) -> tuple[dict, set]:
+async def _resolve_markers(
+    view: Callable, request: Request, path_params: dict[str, Any]
+) -> tuple[dict, set]:
     """Validate a view's Query/Header/Cookie/Path/Form/File markers into kwargs.
 
     Returns ``({param: value}, drop_keys)`` where ``drop_keys`` are path-param
@@ -599,7 +601,7 @@ class _RequestResolver:
             self.teardowns.append(teardown)
         return value
 
-    async def resolve_provider(self, provider: Callable):
+    async def resolve_provider(self, provider: Callable) -> Any:
         key = provider
         try:
             return self.provider_cache[key]
@@ -718,7 +720,9 @@ class BaseRoute:
         else:
             await run_in_threadpool(hook, *args)
 
-    async def _route_auth_injections(self, request) -> dict[str, Any]:
+    async def _route_auth_injections(
+        self, request: Request | WebSocket
+    ) -> dict[str, Any]:
         route_auth = getattr(self.endpoint, "_route_auth", ())
         if not route_auth:
             return {}
@@ -866,7 +870,12 @@ class Route(BaseRoute):
             )
 
     async def _send_validation_error(
-        self, scope: Scope, receive: Receive, send: Send, response: Response, exc
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+        response: Response,
+        exc: Exception,
     ) -> None:
         response.status_code = 422
         errors = _validation_errors(exc)
@@ -883,7 +892,9 @@ class Route(BaseRoute):
         )
         await response(scope, receive, send)
 
-    async def _run_hooks(self, hooks, request: Request, response: Response) -> bool:
+    async def _run_hooks(
+        self, hooks: Iterable[Callable], request: Request, response: Response
+    ) -> bool:
         for hook in hooks:
             _trace(request._starlette.scope, "before_hook", hook=_callable_label(hook))
             args = (request, response) if _accepts_arg_count(hook, 2) else (request,)
@@ -1371,7 +1382,9 @@ class WebSocketRoute(BaseRoute):
 
         ws.receive = receive_with_timeout  # type: ignore[method-assign]
 
-    async def _run_before_hooks(self, hooks, ws: WebSocket) -> bool:
+    async def _run_before_hooks(
+        self, hooks: Iterable[Callable], ws: WebSocket
+    ) -> bool:
         for hook in hooks:
             await self._dispatch_hook(hook, ws)
             # If a hook closed the connection, short-circuit the endpoint.
@@ -1379,7 +1392,9 @@ class WebSocketRoute(BaseRoute):
                 return False
         return True
 
-    async def _run_after_hooks(self, hooks, ws: WebSocket) -> None:
+    async def _run_after_hooks(
+        self, hooks: Iterable[Callable], ws: WebSocket
+    ) -> None:
         for hook in hooks:
             try:
                 await self._dispatch_hook(hook, ws)
@@ -1418,13 +1433,15 @@ class _AppDependencyState:
         self.lock = asyncio.Lock()
         self.teardowns: list[Callable] = []
 
-    async def resolve(self, name: str, registry) -> Any:
+    async def resolve(self, name: str, registry: dict[str, Any]) -> Any:
         if name in self.cache:
             return self.cache[name]
         async with self.lock:
             return await self._resolve_locked(name, registry, [])
 
-    async def _resolve_locked(self, name, registry, stack) -> Any:
+    async def _resolve_locked(
+        self, name: str, registry: dict[str, Any], stack: list[str]
+    ) -> Any:
         # Runs with self.lock held; recurses via this method (never re-acquires
         # the non-reentrant lock), so app-dependency graphs can't deadlock.
         if name in self.cache:

--- a/responder/testing.py
+++ b/responder/testing.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from typing import Any
 
 
-def assert_problem(response, status: int | None = None, **expected: Any) -> dict:
+def assert_problem(
+    response: Any, status: int | None = None, **expected: Any
+) -> dict:
     """Assert that ``response`` is an ``application/problem+json`` response.
 
     Returns the decoded payload so tests can make additional assertions.

--- a/responder/util/cmd.py
+++ b/responder/util/cmd.py
@@ -196,7 +196,9 @@ class ResponderServer(threading.Thread):
         logger.info("Received signal %d, shutting down...", signum)
         self.stop()
 
-    def wait_until_ready(self, timeout=30, request_timeout=1, delay=0.1) -> bool:
+    def wait_until_ready(
+        self, timeout: int = 30, request_timeout: int = 1, delay: float = 0.1
+    ) -> bool:
         """
         Wait until the server is ready to accept connections.
 


### PR DESCRIPTION
## Summary

Follow-up to #613, which enabled a stricter mypy config. This finishes the job: mypy's `disallow_incomplete_defs` flagged **51 partially-annotated functions across 13 files** — functions that had *some* type hints but were missing a parameter or return annotation. All are now fully annotated, and the flag is enabled so partial annotations fail CI going forward.

## Approach

Annotations only — no runtime behavior, logic, or names changed. Precise types where clear (`str`, `bool`, `int`, `dict`, `Request`, `Response`, `Callable`, `Iterable[Any]`, `str | Path`, `str | None`, …); `Any` only where genuinely dynamic (untyped Starlette routes, arbitrary endpoint callables, polymorphic auth/`roles` inputs, parsed request-body data).

Files touched: `api.py`, `routes.py`, `models.py`, `params.py`, `errors.py`, `testing.py`, `util/cmd.py`, and `ext/{auth,openapi,query,clientgen,pagination,logging}.py`, plus the `pyproject.toml` flag.

A couple of edits went slightly beyond filling gaps, for correctness:
- `Router._route_auth_injections` is shared by HTTP and WebSocket routes, so its param is `Request | WebSocket` (not just `Request`) — mypy caught that the WS path passes a `WebSocket`.

## Verification

- `mypy` clean under the config (now including `disallow_incomplete_defs`)
- `ruff` clean
- Full test suite: **746 passed**, 1 skipped (php not installed)

The test suite is the real guarantee that these annotation-only edits are behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)