### PR TITLE
Reject GraphQL mutations over HTTP GET (CSRF guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Security
+
+- The GraphQL view now rejects mutations sent over HTTP `GET` (returns `405`
+  with `Allow: POST`). `GET` must be safe/idempotent; running a mutation via
+  `GET /graphql?query=mutation{...}` made it CSRF-able (a plain `<img src>`
+  would trigger it with the victim's cookies) and cacheable. Query operations
+  over `GET` are unaffected.
+
 ## [v7.2.0] - 2026-07-01
 
 ### Security

--- a/responder/ext/graphql/__init__.py
+++ b/responder/ext/graphql/__init__.py
@@ -100,6 +100,35 @@ class GraphQLView:
         return problems
 
     @staticmethod
+    def _selects_non_query(query, operation_name):
+        """Whether the operation GraphQL would execute is a mutation/subscription.
+
+        Per the GraphQL-over-HTTP spec, ``GET`` may only run ``query``
+        operations: allowing mutations over ``GET`` makes them CSRF-able (a
+        simple ``<img src>`` triggers them with the victim's cookies) and
+        cacheable. A syntax error returns ``False`` so normal execution can
+        surface it.
+        """
+        from graphql import parse
+        from graphql.language import OperationDefinitionNode, OperationType
+
+        try:
+            document = parse(query)
+        except Exception:
+            return False
+
+        operations = [
+            defn
+            for defn in document.definitions
+            if isinstance(defn, OperationDefinitionNode)
+        ]
+        if operation_name:
+            operations = [
+                op for op in operations if op.name and op.name.value == operation_name
+            ]
+        return any(op.operation is not OperationType.QUERY for op in operations)
+
+    @staticmethod
     def _parse_variables(raw):
         """Parse variables from a string (query param) or return as-is (dict)."""
         if raw is None:
@@ -170,6 +199,18 @@ class GraphQLView:
 
         query, variables, operation_name = await self._resolve_graphql_query(req, resp)
         if query is None:
+            return
+
+        # GET must be safe/idempotent: only allow query operations, never
+        # mutations (which would otherwise be CSRF-able and cacheable via GET).
+        if req.method == "GET" and self._selects_non_query(query, operation_name):
+            resp.status_code = 405
+            resp.headers["Allow"] = "POST"
+            resp.media = {
+                "errors": [
+                    {"message": "Mutations must use POST, not GET."}
+                ]
+            }
             return
 
         if not self.introspection or self.max_depth:

--- a/tests/test_graphql_get_csrf.py
+++ b/tests/test_graphql_get_csrf.py
@@ -1,0 +1,72 @@
+# ruff: noqa: E402
+"""GET requests may only run GraphQL query operations, never mutations.
+
+Allowing a mutation over GET makes it CSRF-able (a plain ``<img src>`` would
+trigger it with the victim's cookies) and cacheable. Mutations must use POST.
+"""
+
+import pytest
+
+graphene = pytest.importorskip("graphene")
+
+from responder.ext.graphql import GraphQLView
+
+
+@pytest.fixture
+def mutation_schema():
+    class Query(graphene.ObjectType):
+        hello = graphene.String()
+
+        def resolve_hello(self, info):
+            return "hi"
+
+    class CreateUser(graphene.Mutation):
+        class Arguments:
+            name = graphene.String(required=True)
+
+        ok = graphene.Boolean()
+
+        def mutate(self, info, name):
+            return CreateUser(ok=True)
+
+    class Mutation(graphene.ObjectType):
+        create_user = CreateUser.Field()
+
+    return graphene.Schema(query=Query, mutation=Mutation)
+
+
+def test_mutation_over_get_is_rejected(api, mutation_schema):
+    api.add_route("/", GraphQLView(schema=mutation_schema, api=api))
+    r = api.requests.get(
+        'http://;/?query=mutation { createUser(name: "eve") { ok } }',
+        headers={"Accept": "json"},
+    )
+    assert r.status_code == 405
+    assert r.headers["Allow"] == "POST"
+    assert "POST" in r.json()["errors"][0]["message"]
+
+
+def test_query_over_get_still_works(api, mutation_schema):
+    api.add_route("/", GraphQLView(schema=mutation_schema, api=api))
+    r = api.requests.get("http://;/?query={ hello }", headers={"Accept": "json"})
+    assert r.status_code == 200
+    assert r.json() == {"data": {"hello": "hi"}}
+
+
+def test_mutation_over_post_still_works(api, mutation_schema):
+    api.add_route("/", GraphQLView(schema=mutation_schema, api=api))
+    r = api.requests.post(
+        "http://;/", json={"query": 'mutation { createUser(name: "eve") { ok } }'}
+    )
+    assert r.status_code == 200
+    assert r.json() == {"data": {"createUser": {"ok": True}}}
+
+
+def test_named_mutation_over_get_is_rejected(api, mutation_schema):
+    # A document with a named mutation selected by operationName is also blocked.
+    api.add_route("/", GraphQLView(schema=mutation_schema, api=api))
+    doc = 'mutation M { createUser(name: "eve") { ok } }'
+    r = api.requests.get(
+        f"http://;/?query={doc}&operationName=M", headers={"Accept": "json"}
+    )
+    assert r.status_code == 405


### PR DESCRIPTION
## Summary

A fresh security audit of the areas the earlier review didn't cover turned this up in the GraphQL extension (`responder/ext/graphql/__init__.py`).

The view executed whatever operation arrived — including mutations sent via **GET** query params:

```
GET /graphql?query=mutation{ createUser(name:"eve"){ ok } }
```

`GET` must be safe and idempotent. Running a mutation over `GET`:
- is **CSRF-able** — a plain `<img src="/graphql?query=mutation{...}">` fires it with the victim's cookies, no token needed;
- is **cacheable / loggable** — proxies and browsers may cache or replay it.

This is the standard GraphQL-over-HTTP requirement (GET = queries only).

## Fix

On a `GET` request, parse the document, find the operation that would execute (respecting `operationName`), and if it's a mutation/subscription, return **`405`** with `Allow: POST` instead of executing it. Query operations over `GET` are unaffected, and `POST` mutations work as before. A syntax error falls through to normal execution so the existing error path still reports it.

## Tests

New `tests/test_graphql_get_csrf.py`: mutation-over-GET → 405, query-over-GET → 200, mutation-over-POST → 200, and a named-operation mutation-over-GET → 405. Existing `tests/test_graphql.py` unaffected.

Full suite: **759 passed**, 1 skipped (php not installed); ruff clean; mypy clean.

## Audit notes (what I looked at but did *not* change)

- **GraphiQL / introspection on by default** — real exposure, but flipping the defaults is an opinionated breaking change and they're already documented as "set `False` in production." Left as-is.
- **Static file serving** — confirmed safe; delegates to Starlette's hardened `StaticFiles` (realpath/commonpath traversal checks).
- **clientgen path-param escaping** — a separate, lower-severity correctness issue (an untrusted OpenAPI spec with a quote/newline in a path-param name breaks the generated client's string literals). Worth a follow-up PR; not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)