### PR TITLE
Escape path-param names in generated client string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   would trigger it with the victim's cookies) and cacheable. Query operations
   over `GET` are unaffected.
 
+### Fixed
+
+- The client generator now escapes path-parameter names when interpolating them
+  into generated string literals (Python `repr`, JS via the JS escaper, Ruby via
+  a new single-quoted escaper). A name containing a quote or backslash in an
+  (untrusted) OpenAPI spec previously produced a client that failed to parse.
+
 ## [v7.2.0] - 2026-07-01
 
 ### Security

--- a/responder/ext/clientgen.py
+++ b/responder/ext/clientgen.py
@@ -452,7 +452,8 @@ def _method_source(
     path_expr = repr(path)
     for raw_name in sorted(path_names, key=len, reverse=True):
         py_name = _identifier(raw_name)
-        path_expr += f".replace('{{{raw_name}}}', _quote({py_name}))"
+        placeholder = repr("{" + raw_name + "}")
+        path_expr += f".replace({placeholder}, _quote({py_name}))"
 
     query_expr = "{" + ", ".join(f"{raw!r}: {py}" for raw, py in query_pairs) + "}"
     body_expr = "body" if body_type is not None else "None"
@@ -473,6 +474,12 @@ def _js_string(value: str) -> str:
 
 
 def _php_string(value: str) -> str:
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def _ruby_string(value: str) -> str:
+    """A Ruby single-quoted string literal (no ``#{}`` interpolation, unlike
+    double-quoted), with the only two meaningful escapes applied."""
     return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
 
 
@@ -536,7 +543,8 @@ def _js_method_source(
     path_expr = _js_string(path)
     for raw_name in sorted(path_names, key=len, reverse=True):
         js_name = _camel_identifier(raw_name)
-        path_expr += f".replace('{{{raw_name}}}', quote({js_name}))"
+        placeholder = _js_string("{" + raw_name + "}")
+        path_expr += f".replace({placeholder}, quote({js_name}))"
     query_expr = (
         "{"
         + ", ".join(f"{_js_string(raw)}: {js_name}" for raw, js_name in query_pairs)
@@ -876,11 +884,14 @@ def _ruby_method_source(
     signature = ", ".join([*required_parts, *optional_parts])
     if signature:
         signature = f"({signature})"
-    path_expr = repr(path)
+    path_expr = _ruby_string(path)
     for raw_name in sorted(path_names, key=len, reverse=True):
         rb_name = _identifier(raw_name)
-        path_expr += f".gsub('{{{raw_name}}}', quote({rb_name}))"
-    query_expr = "{" + ", ".join(f"{raw!r} => {rb}" for raw, rb in query_pairs) + "}"
+        placeholder = _ruby_string("{" + raw_name + "}")
+        path_expr += f".gsub({placeholder}, quote({rb_name}))"
+    query_expr = (
+        "{" + ", ".join(f"{_ruby_string(raw)} => {rb}" for raw, rb in query_pairs) + "}"
+    )
     body_expr = "body" if body_type is not None else "nil"
     return (
         f"  def {name}{signature}\n"

--- a/tests/test_clientgen_pathparam_escaping.py
+++ b/tests/test_clientgen_pathparam_escaping.py
@@ -1,0 +1,63 @@
+"""Path-parameter names from an (untrusted) OpenAPI spec must be escaped when
+interpolated into generated client string literals.
+
+A name containing a quote/backslash/newline previously broke out of the
+single-quoted `.replace('{name}', ...)` / `.gsub(...)` literal, producing a
+client that fails to parse. We feed a hostile spec and check the output is
+well-formed.
+"""
+
+from responder.ext.clientgen import _js_string, _ruby_string, generate_client
+
+# A path-parameter name loaded with characters that break naive string
+# interpolation: single quote, backslash, and a newline.
+NASTY = "a'b\\c\nd"
+
+
+def _spec():
+    return {
+        "openapi": "3.0.2",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/x/{" + NASTY + "}": {
+                "get": {
+                    "operationId": "get_x",
+                    "parameters": [
+                        {
+                            "name": NASTY,
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        }
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+
+
+def test_python_client_compiles_with_hostile_path_param():
+    src = generate_client(_spec(), language="python")
+    # Would raise SyntaxError before the fix (unescaped quote/newline in literal).
+    compile(src, "<generated>", "exec")
+
+
+def test_javascript_placeholder_is_escaped():
+    src = generate_client(_spec(), language="javascript")
+    # The placeholder is emitted through the JS string escaper, so the quote
+    # can't break out of the literal in the generated `.replace(...)` call.
+    placeholder = _js_string("{" + NASTY + "}")
+    assert f".replace({placeholder}, quote(" in src
+
+
+def test_ruby_placeholder_is_escaped():
+    src = generate_client(_spec(), language="ruby")
+    placeholder = _ruby_string("{" + NASTY + "}")
+    assert f".gsub({placeholder}, quote(" in src
+
+
+def test_typescript_client_still_generates():
+    # TS shares the JS emitter; just ensure it doesn't blow up.
+    src = generate_client(_spec(), language="typescript")
+    assert "get_x" in src or "getX" in src


### PR DESCRIPTION
## Summary

Follow-up hardening from the fresh audit. The client generator interpolated OpenAPI path-parameter names directly into single-quoted string literals in the generated Python/JavaScript/Ruby clients:

```python
path_expr += f".replace('{{{raw_name}}}', _quote({py_name}))"   # Python, before
```

A path-param name containing a `'` or `\` — reachable from an **untrusted** OpenAPI spec (the path-param regex `{([^}:]+)...}` allows both) — breaks out of the literal and produces a client that fails to parse. Impact is limited to broken *generated* output (not generator RCE), but it's a real correctness bug for third-party specs.

## Fix

Emit the `{name}` placeholder through a proper per-language string escaper:
- **Python** → `repr(...)`
- **JavaScript/TypeScript** → the existing `_js_string(...)`
- **Ruby** → a new `_ruby_string(...)` (single-quoted literal; also applied to the Ruby base path and query-hash keys, which had the same `repr`-for-Ruby quirk where a value with a quote could force a double-quoted literal and re-enable `#{}` interpolation)

**PHP was already correct** and is unchanged — `_php_string` escapes `\` and `'`, and single-quoted PHP tolerates literal newlines (so the audit's PHP "newline" finding was a false positive).

## Tests

New `tests/test_clientgen_pathparam_escaping.py`: feeds a hostile spec (path-param name `a'b\c\n d`) and asserts the generated **Python compiles** (`compile()` — would `SyntaxError` before), and that the JS/Ruby placeholders are emitted through the escaper. The existing multi-language native syntax checks (`test_clientgen.py`) still pass.

Full suite: **759 passed**, 1 skipped (php toolchain not installed locally; runs in CI); ruff clean; mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)