### PR TITLE
Point Homepage metadata at the docs site

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ optional-dependencies.test = [
   "types-pyyaml",
 ]
 urls.Documentation = "https://responder.kennethreitz.org"
-urls.Homepage = "https://github.com/kennethreitz/responder"
+urls.Homepage = "https://responder.kennethreitz.org"
 urls.Issues = "https://github.com/kennethreitz/responder/issues"
 urls.Repository = "https://github.com/kennethreitz/responder"
 scripts.responder = "responder.ext.cli:cli"


### PR DESCRIPTION
Sets the project's `Homepage` URL to https://responder.kennethreitz.org (the docs site) instead of the GitHub repo.

The GitHub link is still present under `Repository`, so nothing is lost — this just makes the primary "Homepage" link on the PyPI sidebar point at the docs.

```
urls.Homepage = "https://responder.kennethreitz.org"   # was the GitHub repo
```

`validate-pyproject` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)