### PR TITLE
Fix multipart field parsing, non-UTF-8 request-id crash, descending-sort None order

### DIFF
--- a/responder/ext/logging.py
+++ b/responder/ext/logging.py
@@ -184,7 +184,10 @@ class LoggingMiddleware:
             return value.decode("latin-1") if value is not None else None
 
         request_id = (
-            headers.get(b"x-request-id", b"").decode() or uuid.uuid4().hex[:8]
+            # ASGI header values are arbitrary bytes; latin-1 never raises
+            # (matches RequestIDMiddleware). A UTF-8 decode would crash the
+            # request on a non-UTF-8 X-Request-ID.
+            headers.get(b"x-request-id", b"").decode("latin-1") or uuid.uuid4().hex[:8]
         )
         scope["request_id"] = request_id
         method = scope.get("method", "WS")

--- a/responder/ext/query.py
+++ b/responder/ext/query.py
@@ -35,12 +35,19 @@ def _value(item, field):
     return getattr(item, field, None)
 
 
-def _sort_key(field: str) -> Callable[[Any], tuple[bool, Any]]:
-    """A sort key for ``field`` that puts ``None`` values last."""
+def _sort_key(field: str, descending: bool) -> Callable[[Any], tuple[bool, Any]]:
+    """A sort key for ``field`` that puts ``None`` values last, regardless of
+    sort direction.
+
+    The list is sorted with ``reverse=descending``, which would otherwise flip
+    the ``None`` flag and pull ``None`` values to the front on a descending
+    sort. Choosing the flag as ``(value is None) != descending`` counteracts the
+    reverse, so ``None`` always lands last.
+    """
 
     def key(item: Any) -> tuple[bool, Any]:
         value = _value(item, field)
-        return (value is None, value)
+        return ((value is None) != descending, value)
 
     return key
 
@@ -82,7 +89,7 @@ def sort_items(items: Any, spec: str | None, *, allowed: Any = None) -> list:
     # Apply keys right-to-left; Python's stable sort yields correct precedence.
     for field, descending in reversed(order):
         try:
-            result.sort(key=_sort_key(field), reverse=descending)
+            result.sort(key=_sort_key(field, descending), reverse=descending)
         except TypeError as exc:
             raise HTTPException(
                 status_code=400, detail=f"Cannot sort by {field!r}: incomparable values"

--- a/responder/formats.py
+++ b/responder/formats.py
@@ -4,6 +4,8 @@ import dataclasses
 import datetime as _dt
 import json
 from decimal import Decimal
+from email.message import Message
+from email.utils import collapse_rfc2231_value
 from urllib.parse import urlencode
 from uuid import UUID
 
@@ -143,6 +145,20 @@ def _parse_multipart(content: bytes, content_type: str) -> list[_PartData]:
     return parts
 
 
+def _content_disposition_param(header: str, param: str) -> str | None:
+    """Extract a single Content-Disposition parameter (e.g. ``name``), using a
+    real header parser so quoting and RFC 2231 encoding are handled correctly."""
+    message = Message()
+    message["content-disposition"] = header
+    value = message.get_param(param, header="content-disposition")
+    if value is None:
+        return None
+    # RFC 2231 extended values come back as a (charset, lang, value) tuple.
+    if isinstance(value, tuple):
+        return collapse_rfc2231_value(value)
+    return value
+
+
 async def format_form(r, encode=False):
     if encode:
         return None
@@ -152,22 +168,23 @@ async def format_form(r, encode=False):
         queries = []
         for part in parts:
             header = part.headers.get("Content-Disposition", "")
+            if not header:
+                continue
+            # A part with a filename is a file, not a text field — read those
+            # via req.media("files"). Skip it (this also stops a file's name
+            # from leaking in as a phantom form field).
+            if _content_disposition_param(header, "filename") is not None:
+                continue
+            name = _content_disposition_param(header, "name")
+            if name is None:
+                continue
             try:
                 text = part.body.decode("utf-8")
             except UnicodeDecodeError:
-                # A binary part (a file) — not a text form field; use
-                # req.media("files") for those.
                 continue
+            queries.append((name, text))
 
-            for section in [h.strip() for h in header.split(";")]:
-                split = section.split("=")
-                if len(split) > 1:
-                    key = split[1]
-                    key = key[1:-1]
-                    queries.append((key, text))
-
-        content = urlencode(queries)
-        return QueryDict(content)
+        return QueryDict(urlencode(queries))
     return QueryDict(await r.text)
 
 

--- a/tests/test_correctness_fixes.py
+++ b/tests/test_correctness_fixes.py
@@ -1,0 +1,123 @@
+"""Regression tests for three correctness fixes:
+
+- multipart form parsing no longer emits file parts / filenames as fields
+- LoggingMiddleware tolerates a non-UTF-8 X-Request-ID
+- descending sort keeps None values last (per the documented contract)
+"""
+
+import asyncio
+
+from starlette.testclient import TestClient
+
+import responder
+from responder.ext.query import sort_items
+
+# --------------------------------------------------------------------------
+# Multipart form parsing (responder/formats.py)
+# --------------------------------------------------------------------------
+
+
+def _form_api():
+    api = responder.API(allowed_hosts=[";"], session_https_only=False)
+
+    @api.route("/form", methods=["POST"])
+    async def form(req, resp):
+        data = await req.media("form")
+        resp.media = {key: data[key] for key in data}
+
+    return api
+
+
+def test_multipart_text_field_is_parsed():
+    api = _form_api()
+    r = TestClient(api, base_url="http://;").post("/form", data={"name": "widget"})
+    assert r.json() == {"name": "widget"}
+
+
+def test_multipart_excludes_files_and_does_not_leak_filenames():
+    api = _form_api()
+    # A UTF-8-decodable "file" plus a real field. The old parser harvested the
+    # file's `filename` as a phantom field keyed by the filename.
+    r = TestClient(api, base_url="http://;").post(
+        "/form",
+        data={"name": "widget"},
+        files={"doc": ("notes.txt", b"hello world", "text/plain")},
+    )
+    body = r.json()
+    assert body == {"name": "widget"}
+    assert "notes.txt" not in body
+    assert "doc" not in body
+
+
+def test_multipart_multiple_fields_keep_their_names():
+    api = _form_api()
+    r = TestClient(api, base_url="http://;").post(
+        "/form", data={"first": "a", "second": "b"}
+    )
+    assert r.json() == {"first": "a", "second": "b"}
+
+
+# --------------------------------------------------------------------------
+# Non-UTF-8 X-Request-ID (responder/ext/logging.py)
+# --------------------------------------------------------------------------
+
+
+def _drive_asgi(app, headers):
+    """Call an ASGI app directly so we can send raw (non-UTF-8) header bytes
+    that an HTTP client would refuse to encode."""
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": headers,
+        "client": ("127.0.0.1", 12345),
+        "server": ("localhost", 80),
+    }
+    sent = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    asyncio.run(app(scope, receive, send))
+    return sent
+
+
+def test_non_utf8_request_id_does_not_crash():
+    api = responder.API(allowed_hosts=["localhost"], enable_logging=True)
+
+    @api.route("/")
+    def index(req, resp):
+        resp.text = "ok"
+
+    # b"\xff\xfe" is valid latin-1 (what ASGI uses for headers) but invalid
+    # UTF-8; the old UTF-8 decode raised in the outermost middleware and
+    # dropped the request. A real HTTP client can't even send these bytes,
+    # so drive the ASGI app directly.
+    headers = [(b"host", b"localhost"), (b"x-request-id", b"\xff\xfe")]
+    sent = _drive_asgi(api, headers)
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    assert start["status"] == 200
+
+
+# --------------------------------------------------------------------------
+# Descending sort keeps None last (responder/ext/query.py)
+# --------------------------------------------------------------------------
+
+
+def test_sort_none_values_last_descending():
+    rows = [{"v": 2}, {"v": None}, {"v": 3}, {"v": 1}]
+    assert [x["v"] for x in sort_items(rows, "-v")] == [3, 2, 1, None]
+
+
+def test_sort_none_values_last_ascending_still_holds():
+    rows = [{"v": "b"}, {"v": None}, {"v": "a"}]
+    assert [x["v"] for x in sort_items(rows, "v")] == ["a", "b", None]


### PR DESCRIPTION
First batch from the comprehensive audit — three confirmed correctness bugs.

### 1. `format_form` leaks file names as phantom form fields (`responder/formats.py`)
The multipart field extraction parsed Content-Disposition by hand:
```python
split = section.split("="); key = split[1]; key = key[1:-1]
```
So a UTF-8-decodable **file** part had its `filename` harvested as a form field keyed by the filename (client-controlled key injection + content leak), and a legitimate **unquoted** `name=field1` became key `ield`. Now parsed with `email`'s real Content-Disposition parser: skip any part carrying a `filename` (those are files — read via `req.media("files")`), take only the `name` parameter (handles quoting + RFC 2231). The case-insensitive boundary handling from #612 is preserved.

### 2. Non-UTF-8 `X-Request-ID` crashes the request (`responder/ext/logging.py`)
`headers.get(b"x-request-id", b"").decode()` used UTF-8, so a client sending `X-Request-ID: \xff\xfe` raised `UnicodeDecodeError` in the outermost observability middleware — outside error handling — dropping the connection whenever `enable_logging=True`. Now decodes as latin-1, matching the sibling `RequestIDMiddleware`.

### 3. Descending sort puts `None` first (`responder/ext/query.py`)
`_sort_key` returned `(value is None, value)` and the list was sorted `reverse=descending`, which flipped the None flag too — pushing `None` rows to the **front** on `-field`, contradicting the documented "None sorts last". The flag now counteracts the reverse (`(value is None) != descending`), so `None` always lands last regardless of direction.

## Tests
New `tests/test_correctness_fixes.py`: multipart excludes files/filenames and keeps field names; non-UTF-8 `X-Request-ID` returns 200 (driven at the ASGI layer since HTTP clients can't send those bytes); descending sort keeps `None` last. Existing form/upload/query/logging tests still pass.

Full suite: **769 passed**, 1 skipped (php); ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)