### PR TITLE
Harden ext concurrency & resource usage (metrics, rate limit, SSE, templates)

### DIFF
--- a/responder/ext/metrics.py
+++ b/responder/ext/metrics.py
@@ -5,6 +5,7 @@ Enabled via ``API(metrics_route="/metrics")`` — no external dependencies.
 
 from __future__ import annotations
 
+import threading
 from collections import defaultdict
 
 # Histogram bucket upper bounds, in seconds.
@@ -62,23 +63,36 @@ class MetricsCollector:
         self.latency_sum: dict[tuple[str, str], float] = defaultdict(float)
         self.latency_count: dict[tuple[str, str], int] = defaultdict(int)
         self.latency_buckets: dict[tuple[str, str, float], int] = defaultdict(int)
+        # Guards the dicts: record() runs per request (possibly from a thread
+        # pool / concurrent tasks) while render() iterates them on a /metrics
+        # scrape. Without this an in-flight record() can raise "dictionary
+        # changed size during iteration" in render(), and increments are lost
+        # on free-threaded CPython.
+        self._lock = threading.Lock()
 
     def record(self, method: str, path: str, status: int, duration: float) -> None:
-        self.requests[(method, path, str(status))] += 1
         key = (method, path)
-        self.latency_sum[key] += duration
-        self.latency_count[key] += 1
-        for bound in BUCKETS:
-            if duration <= bound:
-                self.latency_buckets[(method, path, bound)] += 1
+        with self._lock:
+            self.requests[(method, path, str(status))] += 1
+            self.latency_sum[key] += duration
+            self.latency_count[key] += 1
+            for bound in BUCKETS:
+                if duration <= bound:
+                    self.latency_buckets[(method, path, bound)] += 1
 
     def render(self) -> str:
         """The collected metrics in Prometheus text exposition format."""
+        # Snapshot under the lock, then format without holding it.
+        with self._lock:
+            requests = dict(self.requests)
+            latency_sum = dict(self.latency_sum)
+            latency_count = dict(self.latency_count)
+            latency_buckets = dict(self.latency_buckets)
         lines = [
             "# HELP responder_requests_total Total HTTP requests.",
             "# TYPE responder_requests_total counter",
         ]
-        for (method, path, status), count in sorted(self.requests.items()):
+        for (method, path, status), count in sorted(requests.items()):
             lines.append(
                 f'responder_requests_total{{method="{method}",path="{path}",'
                 f'status="{status}"}} {count}'
@@ -88,10 +102,10 @@ class MetricsCollector:
             "# HELP responder_request_duration_seconds HTTP request latency.",
             "# TYPE responder_request_duration_seconds histogram",
         ]
-        for (method, path), count in sorted(self.latency_count.items()):
+        for (method, path), count in sorted(latency_count.items()):
             cumulative = 0
             for bound in BUCKETS:
-                cumulative = self.latency_buckets.get((method, path, bound), 0)
+                cumulative = latency_buckets.get((method, path, bound), 0)
                 lines.append(
                     f'responder_request_duration_seconds_bucket{{method="{method}",'
                     f'path="{path}",le="{bound}"}} {cumulative}'
@@ -102,7 +116,7 @@ class MetricsCollector:
             )
             lines.append(
                 f'responder_request_duration_seconds_sum{{method="{method}",'
-                f'path="{path}"}} {self.latency_sum[(method, path)]:.6f}'
+                f'path="{path}"}} {latency_sum[(method, path)]:.6f}'
             )
             lines.append(
                 f'responder_request_duration_seconds_count{{method="{method}",'

--- a/responder/ext/ratelimit.py
+++ b/responder/ext/ratelimit.py
@@ -4,7 +4,7 @@ import functools
 import inspect
 import threading
 import time
-from collections import defaultdict
+from collections import OrderedDict
 from typing import Protocol, runtime_checkable
 
 from starlette.concurrency import run_in_threadpool
@@ -33,11 +33,18 @@ class MemoryBackend:
 
     The default backend. Counts are per-process — for multi-process or
     multi-host deployments, use :class:`RedisBackend` instead.
+
+    Keys are bounded: at most ``max_keys`` distinct clients are tracked, with
+    least-recently-seen keys evicted beyond the cap. This stops an attacker who
+    rotates source IPs (or spoofs ``X-Forwarded-For``) from growing process
+    memory without bound. Evicting a key resets its window (fail-open), which is
+    acceptable for an in-memory single-process limiter.
     """
 
-    def __init__(self):
-        self._buckets: dict[str, list[float]] = defaultdict(list)
+    def __init__(self, max_keys: int = 100_000):
+        self._buckets: OrderedDict[str, list[float]] = OrderedDict()
         self._lock = threading.Lock()
+        self._max_keys = max_keys
 
     def hit(self, key, max_requests, period):
         """Record a hit for ``key``. Returns ``(allowed, remaining)``."""
@@ -45,12 +52,15 @@ class MemoryBackend:
         cutoff = now - period
 
         with self._lock:
-            bucket = [t for t in self._buckets[key] if t > cutoff]
+            bucket = [t for t in self._buckets.get(key, ()) if t > cutoff]
+            self._buckets[key] = bucket
+            self._buckets.move_to_end(key)  # mark most-recently-used
             if len(bucket) >= max_requests:
-                self._buckets[key] = bucket
                 return False, 0
             bucket.append(now)
-            self._buckets[key] = bucket
+            # Evict least-recently-used keys once over the cap.
+            while self._max_keys is not None and len(self._buckets) > self._max_keys:
+                self._buckets.popitem(last=False)
             return True, max_requests - len(bucket)
 
 

--- a/responder/models.py
+++ b/responder/models.py
@@ -656,11 +656,15 @@ def _format_sse_event(event: Any) -> bytes:
     return _sse_frame(data=event)
 
 
-async def _sse_with_heartbeat(source, interval):
+async def _sse_with_heartbeat(source, interval, maxsize=1024):
     """Yield from ``source``, injecting a heartbeat comment after ``interval``
     seconds of silence — without cancelling the producer mid-item (a background
-    task feeds a queue; only the idle ``queue.get`` is timed out)."""
-    queue: asyncio.Queue = asyncio.Queue()
+    task feeds a queue; only the idle ``queue.get`` is timed out).
+
+    The queue is bounded (``maxsize``): if the client can't keep up, the
+    producer's ``queue.put`` blocks rather than buffering events without limit,
+    restoring backpressure for slow/stalled consumers."""
+    queue: asyncio.Queue = asyncio.Queue(maxsize=maxsize)
     done = object()
 
     async def pump():

--- a/responder/templates.py
+++ b/responder/templates.py
@@ -1,5 +1,3 @@
-from contextlib import contextmanager
-
 import jinja2
 
 __all__ = ["Templates"]
@@ -10,13 +8,24 @@ class Templates:
         self, directory="templates", autoescape=True, context=None, enable_async=False
     ):
         self.directory = directory
+        loader = jinja2.FileSystemLoader([str(self.directory)])
         self._env = jinja2.Environment(
-            loader=jinja2.FileSystemLoader([str(self.directory)]),
+            loader=loader,
             autoescape=autoescape,  # noqa: S701
             enable_async=enable_async,
         )
+        # A dedicated always-async environment for render_async. Previously a
+        # single shared env had its ``is_async`` toggled per render_async call,
+        # which raced concurrent sync/async renders. The two envs share one
+        # globals dict so context updates apply to both.
+        self._async_env = jinja2.Environment(
+            loader=loader,
+            autoescape=autoescape,  # noqa: S701
+            enable_async=True,
+        )
         self.default_context = {} if context is None else {**context}
         self._env.globals.update(self.default_context)
+        self._async_env.globals = self._env.globals
 
     @property
     def context(self):
@@ -25,6 +34,7 @@ class Templates:
     @context.setter
     def context(self, context):
         self._env.globals = {**self.default_context, **context}
+        self._async_env.globals = self._env.globals
 
     def get_template(self, name):
         return self._env.get_template(name)
@@ -38,17 +48,10 @@ class Templates:
         """  # noqa: E501
         return self.get_template(template).render(*args, **kwargs)
 
-    @contextmanager
-    def _async(self):
-        self._env.is_async = True
-        try:
-            yield
-        finally:
-            self._env.is_async = False
-
     async def render_async(self, template, *args, **kwargs):
-        with self._async():
-            return await self.get_template(template).render_async(*args, **kwargs)
+        return await self._async_env.get_template(template).render_async(
+            *args, **kwargs
+        )
 
     def render_string(self, source, *args, **kwargs):
         """Renders the given `jinja2 <http://jinja.pocoo.org/docs/>`_ template string, with provided values supplied.

--- a/tests/test_concurrency_hardening.py
+++ b/tests/test_concurrency_hardening.py
@@ -1,0 +1,140 @@
+"""Concurrency & resource-exhaustion hardening:
+
+- MetricsCollector is lock-guarded (no crash / lost counts under concurrency)
+- rate-limit MemoryBackend evicts keys (bounded memory)
+- SSE heartbeat uses a bounded queue (backpressure, correct delivery)
+- Templates use a dedicated async env (no shared is_async toggle race)
+"""
+
+import asyncio
+import threading
+
+from responder.ext.metrics import MetricsCollector
+from responder.ext.ratelimit import MemoryBackend
+from responder.models import _sse_with_heartbeat
+from responder.templates import Templates
+
+# --------------------------------------------------------------------------
+# Metrics collector — concurrent record() / render()
+# --------------------------------------------------------------------------
+
+
+def test_metrics_collector_concurrent_record_and_render():
+    collector = MetricsCollector()
+    errors = []
+    stop = threading.Event()
+
+    def writer():
+        while not stop.is_set():
+            collector.record("GET", "/x", 200, 0.01)
+
+    def reader():
+        try:
+            while not stop.is_set():
+                collector.render()
+        except Exception as exc:  # a lock-free version raised "changed size"
+            errors.append(exc)
+
+    threads = [threading.Thread(target=writer) for _ in range(4)]
+    threads += [threading.Thread(target=reader) for _ in range(2)]
+    for t in threads:
+        t.start()
+    threading.Event().wait(0.2)
+    stop.set()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    # No increments were lost to races.
+    assert collector.requests[("GET", "/x", "200")] > 0
+
+
+def test_metrics_record_counts_are_exact_under_threads():
+    collector = MetricsCollector()
+    n = 2000
+    threads = [
+        threading.Thread(
+            target=lambda: [collector.record("GET", "/y", 200, 0.01) for _ in range(n)]
+        )
+        for _ in range(4)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert collector.requests[("GET", "/y", "200")] == n * 4
+
+
+# --------------------------------------------------------------------------
+# Rate-limit MemoryBackend — bounded keys
+# --------------------------------------------------------------------------
+
+
+def test_memory_backend_evicts_least_recently_used_keys():
+    backend = MemoryBackend(max_keys=3)
+    for i in range(10):
+        backend.hit(f"ip-{i}", max_requests=5, period=60)
+    assert len(backend._buckets) <= 3
+    # The most recent keys are retained.
+    assert "ip-9" in backend._buckets
+    assert "ip-0" not in backend._buckets
+
+
+def test_memory_backend_still_limits_within_cap():
+    backend = MemoryBackend(max_keys=100)
+    results = [backend.hit("client", max_requests=2, period=60) for _ in range(3)]
+    assert [allowed for allowed, _ in results] == [True, True, False]
+
+
+# --------------------------------------------------------------------------
+# SSE heartbeat — bounded queue delivers all items in order
+# --------------------------------------------------------------------------
+
+
+def test_sse_heartbeat_bounded_queue_delivers_in_order():
+    async def produce():
+        for i in range(50):
+            yield {"data": str(i)}
+
+    async def drain():
+        seen = []
+        # Tiny queue + a long heartbeat interval so no keepalives fire.
+        async for item in _sse_with_heartbeat(produce(), interval=100, maxsize=2):
+            seen.append(item["data"])
+        return seen
+
+    seen = asyncio.run(drain())
+    assert seen == [str(i) for i in range(50)]
+
+
+# --------------------------------------------------------------------------
+# Templates — dedicated async environment, no shared toggle
+# --------------------------------------------------------------------------
+
+
+def test_templates_use_separate_async_env(tmp_path):
+    (tmp_path / "t.html").write_text("{{ var }}")
+    templates = Templates(directory=tmp_path)
+
+    assert templates._env.is_async is False
+    assert templates._async_env.is_async is True
+
+    async def render_it():
+        return await templates.render_async("t.html", var="hi")
+
+    assert asyncio.run(render_it()) == "hi"
+    # The sync env's is_async was never toggled by the async render.
+    assert templates._env.is_async is False
+    # Sync render still works afterward.
+    assert templates.render("t.html", var="yo") == "yo"
+
+
+def test_templates_share_globals_across_envs(tmp_path):
+    (tmp_path / "t.html").write_text("{{ g }}")
+    templates = Templates(directory=tmp_path, context={"g": "global"})
+    assert templates.render("t.html") == "global"
+
+    async def render_it():
+        return await templates.render_async("t.html")
+
+    assert asyncio.run(render_it()) == "global"


### PR DESCRIPTION
Batch 2 from the audit — four confirmed concurrency / resource-exhaustion findings in the `ext/` and streaming layers.

### 1. MetricsCollector: lock-free dict mutation/iteration (`ext/metrics.py`)
`record()` mutated plain `defaultdict`s while `render()` iterated them. A concurrent `/metrics` scrape during an in-flight request could raise `RuntimeError: dictionary changed size during iteration` (500 the scrape), and increments were lost under free-threaded CPython (3.14t — which the project's classifiers advertise). Now `record()`/`render()` take a `threading.Lock`, and `render()` snapshots under the lock then formats without holding it.

### 2. Rate-limit MemoryBackend: unbounded key growth (`ext/ratelimit.py`)
The sliding-window store never evicted keys, so a client rotating source IPs (or spoofing `X-Forwarded-For`) grew process RSS without bound. Keys now live in an LRU `OrderedDict` with a `max_keys` cap (default 100 000); least-recently-seen keys are evicted past the cap. Eviction resets a key's window (fail-open) — acceptable for an in-memory single-process limiter, and documented as such.

### 3. SSE heartbeat: unbounded queue (`models.py`)
`_sse_with_heartbeat` pumped the producer into `asyncio.Queue()` with no bound, so a slow/stalled client made the queue (and memory) grow without limit. The queue is now bounded (`maxsize`, default 1024); when full the producer's `put` blocks, restoring backpressure.

### 4. Templates: shared `is_async` toggle race (`templates.py`)
`render_async` flipped `is_async` on the single shared Jinja `Environment` and flipped it back, racing any concurrent sync/async render. Now there's a dedicated always-async `Environment` (sharing one globals dict with the sync env), so nothing is toggled.

## Tests
New `tests/test_concurrency_hardening.py` (7 tests): threaded record/render with no crash and exact counts; LRU key eviction + limiting-within-cap; bounded-queue in-order delivery; separate async env with `is_async` never toggled + shared globals.

Full suite: **770 passed**, 1 skipped (php); ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)