### PR TITLE
Improve content negotiation: Accept ranges/q-values, msgpack detect, request charset

### DIFF
--- a/responder/models.py
+++ b/responder/models.py
@@ -168,6 +168,29 @@ class QueryDict(dict):
         yield from super().items()
 
 
+def _parse_accept(header: str) -> list[tuple[str, str, float]]:
+    """Parse an ``Accept`` header into ``(type, subtype, q)`` media ranges."""
+    ranges: list[tuple[str, str, float]] = []
+    for part in header.split(","):
+        media, _, params = part.strip().partition(";")
+        media = media.strip().lower()
+        if not media:
+            continue
+        type_, _, subtype = media.partition("/")
+        quality = 1.0
+        for param in params.split(";"):
+            key, _, value = param.partition("=")
+            if key.strip().lower() == "q":
+                try:
+                    quality = float(value.strip())
+                except ValueError:
+                    quality = 1.0
+        # Keep an absent subtype empty (a bare "yaml" token) rather than
+        # widening it to "*", so it doesn't match unrelated media types.
+        ranges.append((type_.strip() or "*", subtype.strip(), quality))
+    return ranges
+
+
 class Request:
     """An HTTP request, passed to each view as the first argument.
 
@@ -400,8 +423,18 @@ class Request:
 
     @property
     async def declared_encoding(self):
+        # An explicit (non-standard) "Encoding" header wins, for back-compat.
         if "Encoding" in self.headers:
             return self.headers["Encoding"]
+        # Otherwise honor the standard charset= parameter of Content-Type,
+        # rather than guessing with chardet.
+        content_type = self.headers.get("Content-Type", "")
+        for param in content_type.split(";")[1:]:
+            key, _, value = param.partition("=")
+            if key.strip().lower() == "charset":
+                charset = value.strip().strip('"')
+                if charset:
+                    return charset
         return None
 
     @property
@@ -426,8 +459,29 @@ class Request:
         return self.url.scheme == "https"
 
     def accepts(self, content_type: str) -> bool:
-        """Returns ``True`` if the incoming Request accepts the given ``content_type``."""
-        return content_type in self.headers.get("Accept", [])
+        """Whether the client's ``Accept`` header allows ``content_type``.
+
+        Honors media ranges (``*/*``, ``type/*``) and q-values (a range with
+        ``q=0`` is treated as not acceptable). An absent ``Accept`` header
+        accepts anything. ``content_type`` may be a full media type
+        (``application/json``) or a bare subtype token (``json``).
+        """
+        accept = self.headers.get("Accept")
+        if not accept:
+            return True
+        wanted = content_type.lower()
+        for type_, subtype, quality in _parse_accept(accept):
+            if quality <= 0:
+                continue
+            if "/" in wanted:
+                ctype, _, csubtype = wanted.partition("/")
+                if type_ in ("*", ctype) and subtype in ("*", csubtype):
+                    return True
+            # Bare token (e.g. "json"): match a wildcard range or a subtype/type
+            # that contains the token (keeps the historical substring behavior).
+            elif subtype == "*" or wanted in subtype or wanted in type_:
+                return True
+        return False
 
     async def media(self, format: str | Callable | None = None) -> Any:  # noqa: A002
         """Renders incoming json/yaml/form data as Python objects. Must be awaited.
@@ -439,8 +493,14 @@ class Request:
         if format is None:
             # Media types are case-insensitive (RFC 7231 §3.1.1.1).
             mimetype = self.mimetype.lower()
-            format = "yaml" if "yaml" in mimetype else "json"  # noqa: A001
-            format = "form" if "form" in mimetype else format  # noqa: A001
+            if "msgpack" in mimetype:
+                format = "msgpack"  # noqa: A001
+            elif "yaml" in mimetype:
+                format = "yaml"  # noqa: A001
+            elif "form" in mimetype:
+                format = "form"  # noqa: A001
+            else:
+                format = "json"  # noqa: A001
 
         formatter: Callable
         if isinstance(format, str):

--- a/tests/test_negotiation_fixes.py
+++ b/tests/test_negotiation_fixes.py
@@ -1,0 +1,92 @@
+"""Content-negotiation & decoding fixes:
+
+- accepts() honors media ranges (*/*, type/*) and q-values
+- media() auto-detects msgpack
+- request body decoding honors the Content-Type charset= parameter
+"""
+
+import msgpack
+from starlette.testclient import TestClient
+
+import responder
+
+
+def _client(api):
+    return TestClient(api, base_url="http://;")
+
+
+def _accepts_api():
+    api = responder.API(allowed_hosts=[";"], session_https_only=False)
+
+    @api.route("/a")
+    def view(req, resp):
+        resp.media = {
+            "full": req.accepts("application/json"),
+            "token": req.accepts("json"),
+        }
+
+    return api
+
+
+def test_accepts_wildcard_range():
+    r = _client(_accepts_api()).get("/a", headers={"Accept": "*/*"})
+    assert r.json() == {"full": True, "token": True}
+
+
+def test_accepts_type_wildcard():
+    r = _client(_accepts_api()).get("/a", headers={"Accept": "application/*"})
+    assert r.json()["full"] is True
+
+
+def test_accepts_exact_and_qvalue_zero():
+    api = _accepts_api()
+    assert _client(api).get("/a", headers={"Accept": "application/json"}).json()["full"]
+    # q=0 means "not acceptable".
+    r = _client(api).get(
+        "/a", headers={"Accept": "application/json;q=0, text/html"}
+    )
+    assert r.json()["full"] is False
+
+
+def test_accepts_absent_header_accepts_anything():
+    # Starlette TestClient sends a default Accept of */* when omitted, so send
+    # an explicit empty header to exercise the "absent" branch.
+    r = _client(_accepts_api()).get("/a", headers={"Accept": ""})
+    assert r.json() == {"full": True, "token": True}
+
+
+def test_accepts_non_matching_type():
+    r = _client(_accepts_api()).get("/a", headers={"Accept": "text/html"})
+    assert r.json() == {"full": False, "token": False}
+
+
+def test_media_autodetects_msgpack():
+    api = responder.API(allowed_hosts=[";"], session_https_only=False)
+
+    @api.route("/m", methods=["POST"])
+    async def view(req, resp):
+        resp.media = {"got": await req.media()}
+
+    body = msgpack.packb({"x": 1, "y": [1, 2, 3]})
+    r = _client(api).post(
+        "/m", content=body, headers={"Content-Type": "application/x-msgpack"}
+    )
+    assert r.status_code == 200
+    assert r.json() == {"got": {"x": 1, "y": [1, 2, 3]}}
+
+
+def test_request_body_honors_declared_charset():
+    api = responder.API(allowed_hosts=[";"], session_https_only=False)
+
+    @api.route("/t", methods=["POST"])
+    async def view(req, resp):
+        resp.media = {"text": await req.text}
+
+    # "café" encoded as latin-1; a UTF-8 or chardet guess would mangle it.
+    r = _client(api).post(
+        "/t",
+        content="café".encode("latin-1"),
+        headers={"Content-Type": "text/plain; charset=iso-8859-1"},
+    )
+    assert r.status_code == 200
+    assert r.json() == {"text": "café"}


### PR DESCRIPTION
Batch 3 from the audit — three confirmed content-negotiation / decoding findings (all in `models.py`).

### 1. `accepts()` ignored media ranges and q-values
`return content_type in self.headers.get("Accept", [])` substring-matched the raw Accept header, so `Accept: */*` did **not** accept `application/json`, and `q=0` (explicitly *not acceptable*) was ignored. Now the header is parsed into `(type, subtype, q)` ranges: wildcards (`*/*`, `type/*`) match, `q=0` is treated as unacceptable, and an absent `Accept` accepts anything. Bare subtype tokens (the framework's internal `req.accepts("json")` negotiation) keep their historical substring behavior, so response negotiation is unchanged (`json` is still first in the formats dict → `*/*` still yields JSON).

### 2. `media()` never auto-detected msgpack
The auto-detect ladder was yaml/form/json only, so an `application/x-msgpack` body fell through to the JSON parser and 400'd (`Invalid JSON body`) even though the msgpack formatter is registered. Added a msgpack branch.

### 3. Request body ignored the declared charset
`declared_encoding` only checked a non-standard `Encoding` header, so a body sent as `Content-Type: text/plain; charset=iso-8859-1` was decoded by **chardet guessing** rather than the declared charset. Now honors the standard `charset=` parameter first; chardet remains the no-charset fallback.

## Tests
New `tests/test_negotiation_fixes.py` (7 tests): `*/*` and `type/*` ranges, `q=0`, absent/non-matching Accept; msgpack auto-detect round-trip; latin-1 body decoded per declared charset. Existing negotiation tests (incl. `test_yaml_media`) still pass — I caught and fixed one bare-token edge in the Accept parser during verification.

Full suite: **770 passed**, 1 skipped (php); ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)