### PR TITLE
Support nested inline Depends; cache dependency & body-param inspection

### DIFF
--- a/responder/routes.py
+++ b/responder/routes.py
@@ -225,16 +225,67 @@ def _dep_param_specs(provider: Callable) -> tuple[tuple[str, Any], ...]:
     return specs
 
 
+_DEPENDS_PARAMS_CACHE: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+
+
 def _depends_params(view: Callable) -> dict[str, _Depends]:
+    """Cached ``{param_name: Depends(...)}`` for a view/provider's inline
+    ``Depends`` defaults. Signature inspection is comparatively expensive and
+    runs on the per-request path."""
+    key = getattr(view, "__func__", view)
+    try:
+        return _DEPENDS_PARAMS_CACHE[key]
+    except (KeyError, TypeError):
+        pass
     try:
         params = inspect.signature(view).parameters
     except (TypeError, ValueError):
-        return {}
-    return {
-        name: param.default
-        for name, param in params.items()
-        if isinstance(param.default, _Depends)
-    }
+        result: dict[str, _Depends] = {}
+    else:
+        result = {
+            name: param.default
+            for name, param in params.items()
+            if isinstance(param.default, _Depends)
+        }
+    try:
+        _DEPENDS_PARAMS_CACHE[key] = result
+    except TypeError:
+        pass
+    return result
+
+
+_BODY_MODEL_CANDIDATES_CACHE: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+
+
+def _body_model_candidates(endpoint: Callable) -> tuple[tuple[str, Any], ...]:
+    """Cached ``(name, model)`` pairs for an endpoint's Pydantic-model body
+    parameters that have no default. The per-request path/dependency/auth
+    filtering is applied by the caller; only the signature/hint inspection is
+    memoized here (it runs on every write request otherwise)."""
+    key = getattr(endpoint, "__func__", endpoint)
+    try:
+        return _BODY_MODEL_CANDIDATES_CACHE[key]
+    except (KeyError, TypeError):
+        pass
+    hints = _view_type_hints(endpoint)
+    try:
+        sig_params: Any = inspect.signature(endpoint).parameters
+    except (TypeError, ValueError):
+        sig_params = {}
+    candidates = tuple(
+        (name, hints[name])
+        for name in _view_param_names(endpoint)
+        if _is_pydantic_model(hints.get(name))
+        and (
+            name not in sig_params
+            or sig_params[name].default is inspect.Parameter.empty
+        )
+    )
+    try:
+        _BODY_MODEL_CANDIDATES_CACHE[key] = candidates
+    except TypeError:
+        pass
+    return candidates
 
 
 def _accepts_arg_count(view: Callable, count: int) -> bool:
@@ -581,17 +632,21 @@ class _RequestResolver:
         try:
             kwargs: dict[str, Any] = {}
             specs = _dep_param_specs(provider)
+            depends = _depends_params(provider)
             for pname, ann in specs:
                 if _is_request_param(pname, ann, self.req_names):
                     kwargs[pname] = self.request
+                elif pname in depends:
+                    kwargs[pname] = await self.resolve_provider(depends[pname].provider)
                 elif pname in self.registry:
                     kwargs[pname] = await self.resolve(pname)
                 else:
                     chain = " -> ".join(self.stack)
                     raise DependencyResolutionError(
                         f"Parameter {pname!r} of dependency {name!r} is neither the "
-                        f"request (name it 'req' / annotate 'Request') nor a "
-                        f"registered dependency. Dependency chain: {chain}."
+                        f"request (name it 'req' / annotate 'Request'), a registered "
+                        f"dependency, nor an inline Depends(...). "
+                        f"Dependency chain: {chain}."
                     )
         finally:
             self.stack.pop()
@@ -614,17 +669,20 @@ class _RequestResolver:
         self.stack.append(label)
         try:
             kwargs: dict[str, Any] = {}
+            depends = _depends_params(provider)
             for pname, ann in _dep_param_specs(provider):
                 if _is_request_param(pname, ann, self.req_names):
                     kwargs[pname] = self.request
+                elif pname in depends:
+                    kwargs[pname] = await self.resolve_provider(depends[pname].provider)
                 elif pname in self.registry:
                     kwargs[pname] = await self.resolve(pname)
                 else:
                     chain = " -> ".join(self.stack)
                     raise DependencyResolutionError(
                         f"Parameter {pname!r} of dependency provider {label!r} "
-                        "is neither the request nor a registered dependency. "
-                        f"Dependency chain: {chain}."
+                        "is neither the request, a registered dependency, nor an "
+                        f"inline Depends(...). Dependency chain: {chain}."
                     )
         finally:
             self.stack.pop()
@@ -924,28 +982,21 @@ class Route(BaseRoute):
         ):
             return {}
 
-        hints = _view_type_hints(self.endpoint)
+        candidates = _body_model_candidates(self.endpoint)
+        if not candidates:
+            return {}
         dep_names = scope.get("dependencies") or {}
         auth_names = (
             _AUTH_INJECTION_NAMES
             if getattr(self.endpoint, "_route_auth", ())
             else frozenset()
         )
-        try:
-            sig_params: Any = inspect.signature(self.endpoint).parameters
-        except (TypeError, ValueError):
-            sig_params = {}
         model_params = [
-            (name, hints[name])
-            for name in _view_param_names(self.endpoint)
+            (name, model)
+            for name, model in candidates
             if name not in path_params
             and name not in dep_names
             and name not in auth_names
-            and _is_pydantic_model(hints.get(name))
-            and (
-                name not in sig_params
-                or sig_params[name].default is inspect.Parameter.empty
-            )
         ]
         if not model_params:
             return {}

--- a/tests/test_di_nesting.py
+++ b/tests/test_di_nesting.py
@@ -1,0 +1,47 @@
+"""Inline Depends(...) can now nest inside a provider (sub-dependency chains),
+matching the FastAPI pattern. Previously only named @api.dependency() providers
+could chain; a provider with an inline Depends default raised
+DependencyResolutionError."""
+
+import responder
+from responder import Depends
+
+
+def _api():
+    return responder.API(allowed_hosts=[";"], session_https_only=False)
+
+
+def test_inline_depends_nests_inside_provider():
+    api = _api()
+
+    def get_db():
+        return "db-conn"
+
+    def get_user(db=Depends(get_db)):
+        return f"user@{db}"
+
+    @api.route("/me")
+    def me(req, resp, *, user=Depends(get_user)):
+        resp.text = user
+
+    assert api.requests.get("/me").text == "user@db-conn"
+
+
+def test_inline_depends_deeper_chain_and_request_access():
+    api = _api()
+
+    def get_prefix():
+        return "id"
+
+    def get_token(req, prefix=Depends(get_prefix)):
+        return f"{prefix}:{req.headers.get('X-Token', 'anon')}"
+
+    def get_principal(token=Depends(get_token)):
+        return {"token": token}
+
+    @api.route("/who")
+    def who(req, resp, *, principal=Depends(get_principal)):
+        resp.media = principal
+
+    r = api.requests.get("/who", headers={"X-Token": "abc"})
+    assert r.json() == {"token": "id:abc"}


### PR DESCRIPTION
Batch 4 from the audit — a dependency-injection gap plus two hot-path caching fixes (all `routes.py`).

### 1. Nested inline `Depends` inside a provider (feature gap)
The resolver read a provider's parameter *annotations* (`_dep_param_specs`) but not its `_Depends` **defaults**, so a provider whose own parameter used an inline `Depends(...)` fell through to `DependencyResolutionError`. Only named `@api.dependency()` providers could chain — inline sub-dependencies (the common FastAPI pattern, `Depends(get_db)` inside `Depends(get_current_user)`) were impossible. Both `resolve()` (named) and `resolve_provider()` (inline) now resolve inline `Depends` defaults recursively. Cycle detection via the existing resolution stack still applies.

### 2. `_depends_params` uncached (perf)
It ran `inspect.signature()` on every request at two hot-call sites. Now memoized in a `WeakKeyDictionary` keyed on `__func__`, matching the sibling `_dep_param_specs` / `_view_param_names` caches.

### 3. `_body_injections` recomputed its plan every write request (perf)
Every POST/PUT/PATCH/DELETE recomputed the Pydantic-body-param plan **and** an uncached `inspect.signature()`. The per-endpoint signature/hint work is now memoized (`_body_model_candidates`); only the cheap per-request path/dependency/auth filtering runs per call. Result is identical.

## Tests
New `tests/test_di_nesting.py`: an inline `Depends` nested one and several levels deep (with request access in the chain) now resolves. Existing DI suites (`test_composable_di`, `test_dependencies`, `test_v660_features`) all pass — including the unresolvable-param error case, which correctly still raises (a non-`Depends` unknown param).

Full suite: **765 passed**, 1 skipped (php); ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)