### PR TITLE
Fix WSGI/ASGI mount detection and lifespan app; offload large auto-etag hash

### DIFF
--- a/responder/models.py
+++ b/responder/models.py
@@ -550,6 +550,11 @@ def _multipart_range_header(boundary, content_type, start, end, size):
     ).encode("ascii")
 
 
+def _md5_hex(raw: bytes) -> str:
+    """Hex MD5 digest (not security-sensitive — an ETag)."""
+    return hashlib.md5(raw, usedforsecurity=False).hexdigest()
+
+
 def _strong_etag_core(tag):
     """The quoted core of a strong entity-tag, or ``None`` for weak/invalid."""
     if not tag:
@@ -1524,7 +1529,12 @@ class Response:
                 if isinstance(body, bytes)
                 else str(body).encode(self.encoding or DEFAULT_ENCODING)
             )
-            self.etag = hashlib.md5(raw, usedforsecurity=False).hexdigest()
+            # Hash off the event loop for large bodies so a big auto-etagged
+            # response doesn't block the loop; small bodies stay inline.
+            if len(raw) > 65536:
+                self.etag = await run_in_threadpool(_md5_hex, raw)
+            else:
+                self.etag = _md5_hex(raw)
 
         if self.etag is not None or self.last_modified is not None:
             if self.etag is not None:

--- a/responder/routes.py
+++ b/responder/routes.py
@@ -237,6 +237,36 @@ def _depends_params(view: Callable) -> dict[str, _Depends]:
     }
 
 
+def _is_wsgi_app(app: Any) -> bool:
+    """Whether ``app`` looks like a WSGI (rather than ASGI) application.
+
+    ASGI apps are coroutine functions, callables whose ``__call__`` is a
+    coroutine, or expose ``__asgi_app__``; anything else with a two-positional
+    call signature (``environ, start_response``) is treated as WSGI. Deciding
+    this from the signature — instead of from the text of a ``TypeError`` raised
+    while calling the app — means a genuine ``TypeError`` inside a mounted ASGI
+    sub-app keeps its real traceback rather than being misclassified as WSGI.
+    """
+    if hasattr(app, "__asgi_app__") or not callable(app):
+        return False
+    # ASGI if the app (a function) or its bound ``__call__`` (an instance) is a
+    # coroutine. ``inspect.signature`` resolves an instance to its ``__call__``
+    # signature (self excluded), so a two-positional signature => WSGI.
+    if inspect.iscoroutinefunction(app):
+        return False
+    if not inspect.isroutine(app) and inspect.iscoroutinefunction(app.__call__):
+        return False
+    try:
+        positional = [
+            p
+            for p in inspect.signature(app).parameters.values()
+            if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+        ]
+    except (TypeError, ValueError):
+        return False
+    return len(positional) == 2
+
+
 def _accepts_arg_count(view: Callable, count: int) -> bool:
     try:
         params = inspect.signature(view).parameters.values()
@@ -1711,9 +1741,12 @@ class Router:
         assert message["type"] == "lifespan.startup"
 
         if self._lifespan_handler is not None:
-            # Modern lifespan context manager pattern
+            # Modern lifespan context manager pattern. Expose the API as
+            # scope["app"] so a standard ``async def lifespan(app)`` receives
+            # the application instead of None.
+            scope["app"] = self.api
             try:
-                ctx = self._lifespan_handler(scope.get("app"))
+                ctx = self._lifespan_handler(scope["app"])
                 await ctx.__aenter__()
             except BaseException:
                 msg = traceback.format_exc()
@@ -1793,25 +1826,16 @@ class Router:
                 scope["path"] = path[len(path_prefix) :] or "/"
                 scope["root_path"] = root_path + path_prefix
 
-                if not (inspect.iscoroutinefunction(app) or hasattr(app, "__asgi_app__")):
-                    # Check if it looks like a WSGI app (callable with fewer params)
-                    try:
-                        await app(scope, receive, send)
-                        return
-                    except TypeError as exc:
-                        # Only fall back to WSGI if the error is about call signature
-                        if "argument" not in str(exc) and "positional" not in str(exc):
-                            raise
-                        from typing import cast
+                if _is_wsgi_app(app):
+                    from typing import cast
 
-                        from a2wsgi import WSGIMiddleware
+                    from a2wsgi import WSGIMiddleware
 
-                        wsgi_app = WSGIMiddleware(cast(Any, app))
-                        await cast(Any, wsgi_app)(scope, receive, send)
-                        return
+                    wsgi_app = WSGIMiddleware(cast(Any, app))
+                    await cast(Any, wsgi_app)(scope, receive, send)
                 else:
                     await app(scope, receive, send)
-                    return
+                return
 
         # A near-miss on the trailing slash gets redirected to the real route,
         # preserving the method and query string (307).

--- a/tests/test_mount_lifespan_fixes.py
+++ b/tests/test_mount_lifespan_fixes.py
@@ -1,0 +1,98 @@
+"""Mount, lifespan, and auto-etag fixes:
+
+- a user lifespan context manager receives the API as ``app`` (was None)
+- WSGI-vs-ASGI mount dispatch is decided by signature, so a genuine TypeError
+  inside a mounted ASGI sub-app keeps its real traceback
+- auto_etag still tags large bodies (hashing offloaded off the event loop)
+"""
+
+from contextlib import asynccontextmanager
+
+import pytest
+from starlette.testclient import TestClient
+
+import responder
+
+
+def test_lifespan_receives_the_api_as_app():
+    seen = {}
+
+    @asynccontextmanager
+    async def lifespan(app):
+        seen["app"] = app
+        yield
+
+    api = responder.API(lifespan=lifespan, allowed_hosts=[";"])
+
+    @api.route("/")
+    def index(req, resp):
+        resp.text = "ok"
+
+    with api.requests as session:
+        session.get("http://;/")
+
+    assert seen["app"] is api
+
+
+def test_mounted_asgi_app_real_error_is_not_masked():
+    api = responder.API(allowed_hosts=["localhost"])
+
+    async def broken_asgi(scope, receive, send):
+        # A genuine bug inside the ASGI app — NOT a call-signature error.
+        raise TypeError("boom: a real bug with the word argument in it")
+
+    api.mount("/sub", broken_asgi)
+
+    @api.route("/")
+    def index(req, resp):
+        resp.text = "root"
+
+    client = TestClient(api, base_url="http://localhost", raise_server_exceptions=True)
+    # The real TypeError must propagate, not be swallowed by a WSGI fallback.
+    with pytest.raises(TypeError, match="boom"):
+        client.get("/sub")
+
+
+def test_mounted_asgi_app_still_works():
+    api = responder.API(allowed_hosts=["localhost"])
+
+    async def asgi_ok(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"asgi-ok"})
+
+    api.mount("/sub", asgi_ok)
+    r = TestClient(api, base_url="http://localhost").get("/sub")
+    assert r.status_code == 200
+    assert r.text == "asgi-ok"
+
+
+def test_mounted_wsgi_app_still_works():
+    flask = pytest.importorskip("flask")
+    wsgi = flask.Flask(__name__)
+
+    @wsgi.route("/")
+    def home():
+        return "wsgi-ok"
+
+    api = responder.API(allowed_hosts=["localhost"])
+    api.mount("/wsgi", wsgi)
+    r = TestClient(api, base_url="http://localhost").get("/wsgi/")
+    assert r.status_code == 200
+    assert "wsgi-ok" in r.text
+
+
+def test_auto_etag_large_body_is_tagged():
+    api = responder.API(allowed_hosts=[";"], auto_etag=True, session_https_only=False)
+
+    @api.route("/big")
+    def big(req, resp):
+        resp.text = "x" * 200_000  # exceeds the off-loop hashing threshold
+
+    r = TestClient(api, base_url="http://;").get("/big")
+    assert r.status_code == 200
+    assert "ETag" in r.headers
+    # And the ETag actually validates (conditional 304).
+    r2 = TestClient(api, base_url="http://;").get(
+        "/big", headers={"If-None-Match": r.headers["ETag"]}
+    )
+    assert r2.status_code == 304


### PR DESCRIPTION
Final batch from the audit — mount/lifespan correctness plus one file-serving perf item.

### 1. Mount dispatch misclassified genuine ASGI errors (`routes.py`)
Sub-app dispatch inferred WSGI-vs-ASGI from the **text** of a `TypeError` raised while calling the app:
```python
try:
    await app(scope, receive, send)
except TypeError as exc:
    if "argument" not in str(exc) and "positional" not in str(exc): raise
    ... treat as WSGI ...
```
So a real `TypeError` *inside* a mounted ASGI sub-app (whose message happened to contain "argument"/"positional") was misclassified as WSGI, wrapped in `WSGIMiddleware`, and its real traceback destroyed. Now decided from the call signature up front (`_is_wsgi_app`): a coroutine / async `__call__` / `__asgi_app__` marker ⇒ ASGI; a two-positional `(environ, start_response)` signature ⇒ WSGI.

### 2. Lifespan handler always got `app=None` (`routes.py`)
The handler was invoked as `self._lifespan_handler(scope.get("app"))`, but Responder never set `scope["app"]`, so a standard `async def lifespan(app): ...` always received `None`. Now `scope["app"] = self.api` is set before invoking it.

### 3. auto_etag hashed on the event loop (`models.py`)
`auto_etag` MD5-hashed the response body inline; for a large auto-etagged body that blocks the loop. The hash is now offloaded to a thread above 64 KiB; small bodies (the common case) stay inline with no added overhead.

## Tests
New `tests/test_mount_lifespan_fixes.py`: lifespan receives the API instance; a mounted ASGI app's genuine `TypeError` propagates (not masked); ASGI and Flask/WSGI mounts still work; a 200 KB auto-etagged body is tagged and its ETag validates (304). Existing mount/lifespan/etag suites pass.

Full suite: **768 passed**, 1 skipped (php); ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)