### PR TITLE
Add developer Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# Responder — common developer tasks.
+# Run `make` (or `make help`) to list them. Everything runs through uv.
+
+.DEFAULT_GOAL := help
+UV ?= uv
+
+.PHONY: help uv-sync test lint fix types check docs build lock clean
+
+help:  ## List available commands
+	@grep -hE '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "} {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
+
+uv-sync:  ## Sync the dev virtualenv (develop, test, docs extras)
+	$(UV) sync --extra develop --extra test --extra docs
+
+test: uv-sync  ## Run the test suite with coverage
+	$(UV) run pytest
+
+lint:  ## Lint with ruff
+	$(UV) run ruff check .
+
+fix:  ## Auto-fix lint issues with ruff
+	$(UV) run ruff check --fix .
+
+types:  ## Type-check with mypy
+	$(UV) run mypy
+
+check: lint types test  ## Run lint, type checks, and tests
+
+docs: uv-sync  ## Build the HTML documentation
+	cd docs && $(UV) run make html
+
+build:  ## Build the sdist and wheel
+	$(UV) build
+
+lock:  ## Refresh the uv lock file
+	$(UV) lock
+
+clean:  ## Remove build artifacts and caches
+	rm -rf dist build coverage.xml .pytest_cache .mypy_cache .ruff_cache
+	find . -type d -name '__pycache__' -prune -exec rm -rf {} +


### PR DESCRIPTION
Adds a root `Makefile` for common developer tasks, following the house convention (bare `make` prints help; task targets depend on `make uv-sync`). Everything runs through `uv`.

```
$ make
  help       List available commands
  uv-sync    Sync the dev virtualenv (develop, test, docs extras)
  test       Run the test suite with coverage
  lint       Lint with ruff
  fix        Auto-fix lint issues with ruff
  types      Type-check with mypy
  check      Run lint, type checks, and tests
  docs       Build the HTML documentation
  build      Build the sdist and wheel
  lock       Refresh the uv lock file
  clean      Remove build artifacts and caches
```

- `make test` depends on `make uv-sync`, then runs `uv run pytest` (matches the documented `uv run pytest`).
- `make docs` depends on `uv-sync`, then runs `cd docs && uv run make html` (matches the documented docs build).
- `uv-sync` installs the `develop`, `test`, and `docs` extras as one superset, so switching between `make test` and `make docs` doesn't re-sync the environment back and forth.
- `UV ?= uv` lets you override the uv binary.

Verified locally: `make` (help renders), `make test` (sync + 763 passed), `make lint`, `make types`, and `make docs` (Sphinx build succeeds) all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)