### PR TITLE
docs: cover 7.3.0 features (ws_idle_timeout, nested Depends, bounded rate-limit memory)

### DIFF
--- a/docs/source/tour.rst
+++ b/docs/source/tour.rst
@@ -207,6 +207,22 @@ instead of registering a global name::
 ``Depends`` providers follow the same lifecycle rules as registered
 dependencies, including generator teardown.
 
+``Depends`` also **nests**: a provider's own parameters can use ``Depends``, so
+dependencies compose into chains without registering each one by name::
+
+    def get_db():
+        ...
+
+    def current_user(db=Depends(get_db)):  # a provider depending on a provider
+        return load_user(db)
+
+    @api.route("/me")
+    def me(req, resp, *, user=Depends(current_user)):
+        resp.media = {"user": user}
+
+Each provider resolves once per request and shares the same cache, and cycles
+are detected and reported.
+
 When a dependency is only a guard or setup step, attach it to the route instead
 of adding an unused handler parameter::
 
@@ -1184,6 +1200,16 @@ Dependency teardowns still run when a request times out. One caveat: a
 the client gets the 504 on time, but the thread runs to completion in the
 background.
 
+WebSocket handlers have a matching guard. Pass ``ws_idle_timeout`` to close a
+connection that waits too long for the next inbound message (close code
+``1001``)::
+
+    api = responder.API(ws_idle_timeout=30)  # seconds
+
+The deadline resets on every message received, so it bounds *idle* time between
+messages rather than the total connection lifetime — a continuously active
+client is never closed. It defaults to ``None`` (no timeout).
+
 
 Rate Limiting
 -------------
@@ -1206,8 +1232,11 @@ can pace themselves.
 
 The rate limiter is per-client, keyed by IP address.
 
-By default, counts live in process memory. For multi-process or multi-host
-deployments, plug in the Redis backend so all workers share one budget::
+By default, counts live in process memory. The in-memory store tracks at most
+``max_keys`` distinct clients (100k by default), evicting the least-recently
+seen beyond that, so a client rotating source IPs can't grow memory without
+bound. For multi-process or multi-host deployments, plug in the Redis backend so
+all workers share one budget::
 
     from responder.ext.ratelimit import RateLimiter, RedisBackend
 


### PR DESCRIPTION
Follow-up to the 7.3.0 release: update the hand-written **tour** docs for the new user-facing features. (The `api.rst` reference is autodoc, so it already picks up the new docstrings on rebuild — this is the prose that doesn't auto-update.)

Added to `docs/source/tour.rst`:
- **`ws_idle_timeout`** — documented next to `request_timeout` as the WebSocket sibling (resets per message, closes idle connections with 1001).
- **Nested `Depends`** — a note + example in the dependency-injection section showing a provider that itself uses `Depends` (sub-dependency chains), with a mention of once-per-request caching and cycle detection.
- **Bounded in-memory rate limiter** — a sentence in the rate-limiting section noting the `max_keys` LRU bound (so IP-rotation floods can't grow memory unbounded).

Sphinx build succeeds with no new warnings.

## Not covered here (deliberately)
The content-negotiation improvements (`accepts()` ranges/q-values, request `charset=`, msgpack auto-detect) are refinements to already-documented behavior and didn't have a dedicated prose section worth expanding. Happy to add a short "content negotiation" subsection if you'd like one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)